### PR TITLE
build(deb): Fix build

### DIFF
--- a/debian/control
+++ b/debian/control
@@ -8,10 +8,11 @@ Build-Depends: debhelper (>= 11),
                python3-all,
                python3-debian,
                python3-setuptools,
+               python3-distutils,
                python3-pytest
 Standards-Version: 4.1.3
 Homepage: https://github.com/isantop/repolib
-X-Python3-Version: >= 3.8
+XS-Python3-Version: >= 3.7
 Vcs-Browser: https://github.com/isantop/repolib
 Vcs-Git: https://github.com/isantop/repolib.git
 

--- a/debian/rules
+++ b/debian/rules
@@ -4,6 +4,7 @@
 #export DH_VERBOSE = 1
 
 export PYBUILD_NAME=repolib
+export PYBUILD_OPTION=--test-pytest
 
 %:
 	dh $@ --with python3 --buildsystem=pybuild

--- a/setup.py
+++ b/setup.py
@@ -183,7 +183,7 @@ setup(
     download_url = 'https://github.com/isantop/repolib/releases',
     long_description = long_description,
     tests_require = ['pytest'],
-    license = 'BSD-2',
+    license = 'LGPLv3',
     packages=['repolib', 'repolib/command'],
     cmdclass={'release': Release, 'test': Test},
     scripts=['bin/apt-manage'],


### PR DESCRIPTION
Add test system to rules to ensure builds work in build system. Debhelper and debuild seem to autodetect this. 