### PR TITLE
Add ident field for better handling of filenames

### DIFF
--- a/repolib/__init__.py
+++ b/repolib/__init__.py
@@ -43,15 +43,19 @@ def get_all_sources(get_system=False):
 
     sources = []
 
+    if get_system:
+        source = SystemSource()
+        sources.append(source)
+
     for file in sources_files:
-        if file.name == 'system' and not get_system:
+        if file.stem == 'system':
             continue
-        source = Source(filename=file)
+        source = Source(filename=file.stem)
         source.load_from_file()
         sources.append(source)
 
     for file in list_files:
-        source = LegacyDebSource(filename=file)
+        source = LegacyDebSource(filename=file.stem)
         source.load_from_file()
         sources.append(source)
 

--- a/repolib/command/add.py
+++ b/repolib/command/add.py
@@ -102,8 +102,15 @@ class Add(command.Command):
         self.expand = args.expand
         self.source_code = args.source_code
         self.disable = args.disable
-        self.name = args.name
-        ident = args.identifier.split()
+        try:
+            name = args.name.split()
+        except AttributeError:
+            name = args.name
+        try:
+            ident = args.identifier.split()
+        except AttributeError:
+            ident = args.identifier
+        self.name = ' '.join(name)
         self.ident = '-'.join(ident).translate(CLEAN_CHARS)
 
     def set_names(self, source):

--- a/repolib/command/add.py
+++ b/repolib/command/add.py
@@ -25,7 +25,7 @@ Module for adding repos to the system in CLI applications.
 from ..deb import DebLine
 from ..legacy_deb import LegacyDebSource
 from ..ppa import PPALine
-from ..util import DISTRO_CODENAME
+from ..util import DISTRO_CODENAME, CLEAN_CHARS
 
 from . import command
 
@@ -76,6 +76,12 @@ class Add(command.Command):
             action='store_true',
             help='Display expanded details about the repository before adding it.'
         )
+        options.add_argument(
+            '-n',
+            '--name',
+            default=['x-repolib-default-name'],
+            help='A name to set for the new repo'
+        )
 
     # pylint: disable=too-few-public-methods
     # Thinking of ways to add more, but otherwise this is just simple.
@@ -90,6 +96,7 @@ class Add(command.Command):
         self.expand = args.expand
         self.source_code = args.source_code
         self.disable = args.disable
+        self.name = ' '.join(args.name)
 
     def run(self):
         """ Run the command."""
@@ -142,8 +149,13 @@ class Add(command.Command):
             for repo in new_source.sources:
                 repo.enabled = False
             new_source.enabled = False
-
+        
         new_source.make_names()
+
+        if self.name != 'x-repolib-default-name':
+            new_source.name = self.name
+            file = self.name.lower().split()
+            new_source.ident = '-'.join(file).translate(CLEAN_CHARS)
 
         self.log.debug(new_source.name)
         self.log.debug(new_source.filename)

--- a/repolib/command/add.py
+++ b/repolib/command/add.py
@@ -82,6 +82,12 @@ class Add(command.Command):
             default=['x-repolib-default-name'],
             help='A name to set for the new repo'
         )
+        options.add_argument(
+            '-i',
+            '--identifier',
+            default=['x-repolib-default-id'],
+            help='The identifier/filename to use for the new repo'
+        )
 
     # pylint: disable=too-few-public-methods
     # Thinking of ways to add more, but otherwise this is just simple.
@@ -97,6 +103,7 @@ class Add(command.Command):
         self.source_code = args.source_code
         self.disable = args.disable
         self.name = ' '.join(args.name)
+        self.ident = '-'.join(args.ident).translate(CLEAN_CHARS)
 
     def run(self):
         """ Run the command."""
@@ -156,6 +163,9 @@ class Add(command.Command):
             new_source.name = self.name
             file = self.name.lower().split()
             new_source.ident = '-'.join(file).translate(CLEAN_CHARS)
+        
+        if self.name != 'x-repolib-default-id':
+            new_source.ident = self.ident.lower()
 
         self.log.debug(new_source.name)
         self.log.debug(new_source.filename)

--- a/repolib/command/add.py
+++ b/repolib/command/add.py
@@ -102,8 +102,9 @@ class Add(command.Command):
         self.expand = args.expand
         self.source_code = args.source_code
         self.disable = args.disable
-        self.name = ' '.join(args.name)
-        self.ident = '-'.join(args.identifier).translate(CLEAN_CHARS)
+        self.name = args.name
+        ident = args.identifier.split()
+        self.ident = '-'.join(ident).translate(CLEAN_CHARS)
 
     def set_names(self, source):
         """Set up names for the source.
@@ -114,9 +115,11 @@ class Add(command.Command):
         source.make_names()
 
         if self.name != 'x-repolib-default-name':
+            self.log.debug('Got Name: %s', self.name)
             source.name = self.name
 
         if self.ident != 'x-repolib-default-id':
+            self.log.debug('Got Ident: %s', self.ident)
             source.ident = self.ident.lower()
 
     def run(self):

--- a/repolib/command/add.py
+++ b/repolib/command/add.py
@@ -103,7 +103,21 @@ class Add(command.Command):
         self.source_code = args.source_code
         self.disable = args.disable
         self.name = ' '.join(args.name)
-        self.ident = '-'.join(args.ident).translate(CLEAN_CHARS)
+        self.ident = '-'.join(args.identifier).translate(CLEAN_CHARS)
+
+    def set_names(self, source):
+        """Set up names for the source.
+
+        Arguments:
+            source(repolib.Source): The source for which to set names
+        """
+        source.make_names()
+
+        if self.name != 'x-repolib-default-name':
+            source.name = self.name
+
+        if self.ident != 'x-repolib-default-id':
+            source.ident = self.ident.lower()
 
     def run(self):
         """ Run the command."""
@@ -156,16 +170,8 @@ class Add(command.Command):
             for repo in new_source.sources:
                 repo.enabled = False
             new_source.enabled = False
-        
-        new_source.make_names()
 
-        if self.name != 'x-repolib-default-name':
-            new_source.name = self.name
-            file = self.name.lower().split()
-            new_source.ident = '-'.join(file).translate(CLEAN_CHARS)
-        
-        if self.name != 'x-repolib-default-id':
-            new_source.ident = self.ident.lower()
+        self.set_names(new_source)
 
         self.log.debug(new_source.name)
         self.log.debug(new_source.filename)

--- a/repolib/command/list.py
+++ b/repolib/command/list.py
@@ -90,8 +90,6 @@ class List(command.Command):
         # pylint: disable=too-many-branches
         # The branches involved control program output. Maybe this can be
         # split into separate methods.
-        sources_files = self.sources_dir.glob('*.sources')
-        list_files = self.sources_dir.glob('*.list')
         try:
             sources_list_d_file = self.sources_dir.parent / 'sources.list'
         except FileNotFoundError:

--- a/repolib/command/list.py
+++ b/repolib/command/list.py
@@ -26,6 +26,7 @@ from ..deb import DebLine
 from ..legacy_deb import LegacyDebSource
 from ..source import Source
 from ..util import get_sources_dir, RepoError
+from .. import get_all_sources
 
 from . import command
 
@@ -97,30 +98,11 @@ class List(command.Command):
             sources_list_d_file = None
 
         print('Configured sources:')
-        for file in sources_files:
-            self.log.debug('Found source %s', file.name)
-            source = Source(filename=file.name)
-            source.load_from_file()
-
+        for source in get_all_sources(get_system=True):
+            self.log.debug('Found source file %s', source.filename)
+            print(f'{source.ident} - {source.name}')
             if self.verbose:
                 print(f'{source.make_source_string()}')
-            else:
-                filename = source.filename.replace(".sources", "")
-                print(f'{filename} - {source.name}')
-
-        for file in list_files:
-            source = LegacyDebSource(filename=file.name)
-            source.load_from_file()
-
-            if len(source.sources) > 0:
-                self.log.debug('Found source: %s', file.name)
-
-                if self.verbose:
-                    for debsrc in source.sources:
-                        print(debsrc.make_source_string())
-                else:
-                    filename = source.filename.replace('.list', '')
-                    print(f'{filename} - {source.name}')
 
         if sources_list_d_file and self.legacy:
             print('\n Legacy sources.list entries:\n')

--- a/repolib/deb.py
+++ b/repolib/deb.py
@@ -53,7 +53,7 @@ class DebLine(source.Source):
             )
         self._parse_debline(self.deb_line)
         self.filename = self.make_name(prefix="deb-")
-        self.name = self.filename
+        self.name = self.ident
 
     def copy(self, source_code=True):
         """ Copies the source and returns an identical source object.

--- a/repolib/deb.py
+++ b/repolib/deb.py
@@ -53,7 +53,7 @@ class DebLine(source.Source):
             )
         self._parse_debline(self.deb_line)
         self.filename = self.make_name(prefix="deb-")
-        self.name = self.filename.replace('.sources', '')
+        self.name = self.filename
 
     def copy(self, source_code=True):
         """ Copies the source and returns an identical source object.

--- a/repolib/deb_test.py
+++ b/repolib/deb_test.py
@@ -44,7 +44,7 @@ class DebTestCase(unittest.TestCase):
         self.assertEqual(source.suites, ['suite'])
         self.assertEqual(source.components, ['main'])
         self.assertFalse(source.options)
-        self.assertEqual(source.filename, 'deb-example-com.sources')
+        self.assertEqual(source.ident, 'deb-example-com')
 
     def test_source_with_multiple_components(self):
         source = deb.DebLine(

--- a/repolib/legacy_deb.py
+++ b/repolib/legacy_deb.py
@@ -62,7 +62,7 @@ class LegacyDebSource(source.Source):
     # pylint: disable=super-init-not-called
     # Because this is a sort of meta-source, it needs to be different from the
     # super class.
-    def __init__(self, *args, filename=None, **kwargs):
+    def __init__(self, *args, filename=None, ident=None, **kwargs):
         super().__init__(*args, filename=filename, **kwargs)
         self.sources = []
         self._source_code_enabled = False
@@ -202,6 +202,17 @@ class LegacyDebSource(source.Source):
         for repo in self.sources:
             if util.AptSourceType.SOURCE in repo.types and self.enabled:
                 repo.enabled = enabled
+    
+    @property
+    def filename(self):
+        """str: The filename of the source."""
+        return f'{self.ident}.list'
+    
+    @filename.setter
+    def filename(self, name):
+        name = name.replace('.list', '')
+        name = name.replace('.sources', '')
+        self._ident = name
 
     @property
     def types(self):

--- a/repolib/legacy_deb.py
+++ b/repolib/legacy_deb.py
@@ -63,7 +63,7 @@ class LegacyDebSource(source.Source):
     # Because this is a sort of meta-source, it needs to be different from the
     # super class.
     def __init__(self, *args, filename=None, ident=None, **kwargs):
-        super().__init__(*args, filename=filename, **kwargs)
+        super().__init__(*args, filename=filename, ident=ident, **kwargs)
         self.sources = []
         self._source_code_enabled = False
         self.init_values()
@@ -73,9 +73,8 @@ class LegacyDebSource(source.Source):
 
         It also sets these values up.
         """
-        if not self.filename:
-            self.filename = self.sources[0].make_name()
-            self.filename = self.filename.replace('.sources', '.list')
+        if not self.ident:
+            self.ident = self.sources[0].make_name()
 
         if not self.name:
             self.name = self.sources[0].make_name()
@@ -110,14 +109,13 @@ class LegacyDebSource(source.Source):
         if not self.name:
             self.make_names()
 
-    def load_from_file(self, filename=None):
+    def load_from_file(self, filename=None, ident=None):
         """ Loads the source from a file on disk.
 
         Keyword arguments:
           filename -- STR, Containing the path to the file. (default: self.filename)
         """
-        if filename:
-            self.filename = filename
+        self._set_filename_ident(filename, ident)
         self.sources = []
         name = None
 
@@ -202,17 +200,15 @@ class LegacyDebSource(source.Source):
         for repo in self.sources:
             if util.AptSourceType.SOURCE in repo.types and self.enabled:
                 repo.enabled = enabled
-    
+
     @property
     def filename(self):
         """str: The filename of the source."""
         return f'{self.ident}.list'
-    
+
     @filename.setter
     def filename(self, name):
-        name = name.replace('.list', '')
-        name = name.replace('.sources', '')
-        self._ident = name
+        self._ident = self._clean_name(name)
 
     @property
     def types(self):

--- a/repolib/legacy_deb_test.py
+++ b/repolib/legacy_deb_test.py
@@ -44,7 +44,7 @@ class LegacyTestCase(unittest.TestCase):
                 'deb [arch=armel,amd64 lang=en_US] http://example.com ubuntu main\n'
                 'deb-src [arch=armel,amd64 lang=en_US] http://example.com ubuntu main\n'
             )
-        self.source = legacy_deb.LegacyDebSource(filename='test.list')
+        self.source = legacy_deb.LegacyDebSource(ident='test')
         self.source.load_from_file()
 
     def test_load_from_file(self):

--- a/repolib/ppa.py
+++ b/repolib/ppa.py
@@ -99,7 +99,7 @@ class PPALine(source.Source):
         self.components = ['main']
         ppa_name = ppa_info[1].split('/')
         self.name = 'ppa-{}'.format('-'.join(ppa_name))
-        self.filename = '{}.sources'.format(self.name)
+        self.ident = '{}'.format(self.name)
         if fetch_data:
             self.ppa_info = get_info_from_lp(ppa_owner, ppa_name[1])
             if self.verbose:
@@ -118,7 +118,7 @@ class PPALine(source.Source):
         name = self.ppa_line.replace(':', '-')
         name = name.replace('/', '-')
 
-        return f'{name}.list'
+        return f'{name}'
 
     def save_to_disk(self, save=True):
         """

--- a/repolib/source.py
+++ b/repolib/source.py
@@ -82,11 +82,8 @@ class Source(deb822.Deb822):
         Arguments:
             filename (str): The name of the file on disk.
         """
-        if filename:
-            self.filename = filename
-        if ident:
-            self.ident = ident
-        if not self.filename:
+        self._set_filename_ident(filename, ident)
+        if not self.ident:
             raise SourceError("No filename to load from")
 
         full_path = util.get_sources_dir() / self.filename
@@ -223,6 +220,19 @@ class Source(deb822.Deb822):
 
         return line.strip()
 
+    def _set_filename_ident(self, filename, ident):
+        if filename:
+            self.filename = filename
+        if ident:
+            self.ident = ident
+
+    # pylint: disable=no-self-use
+    # Handy to have for subclasses
+    def _clean_name(self, name):
+        name = name.replace('.list', '')
+        name = name.replace('.sources', '')
+        return name
+
     @property
     def name(self):
         """ str: The name of the source."""
@@ -234,7 +244,7 @@ class Source(deb822.Deb822):
     @name.setter
     def name(self, name):
         self['X-Repolib-Name'] = name
-    
+
     @property
     def ident(self):
         """str: a system-scope identifier for this source. Used for filename."""
@@ -243,21 +253,19 @@ class Source(deb822.Deb822):
         except AttributeError:
             self._ident = None
             return self._ident
-    
+
     @ident.setter
     def ident(self, ident):
         self._ident = ident
-    
+
     @property
     def filename(self):
         """str: The filename of the source."""
         return f'{self.ident}.sources'
-    
+
     @filename.setter
     def filename(self, name):
-        name = name.replace('.list', '')
-        name = name.replace('.sources', '')
-        self._ident = name
+        self._ident = self._clean_name(name)
 
     @property
     def enabled(self):

--- a/repolib/source.py
+++ b/repolib/source.py
@@ -69,11 +69,14 @@ class Source(deb822.Deb822):
     options_re = re.compile(r'[^@.+]\[([^[]+.+)\]\ ')
     uri_re = re.compile(r'\w+:(\/?\/?)[^\s]+')
 
-    def __init__(self, *args, filename=None, **kwargs):
+    def __init__(self, *args, filename=None, ident=None, **kwargs):
         super().__init__(*args, **kwargs)
-        self.filename = filename
+        if filename:
+            self.filename = filename
+        if ident:
+            self.ident = ident
 
-    def load_from_file(self, filename=None):
+    def load_from_file(self, filename=None, ident=None):
         """ Loads the data from a file path.
 
         Arguments:
@@ -81,6 +84,8 @@ class Source(deb822.Deb822):
         """
         if filename:
             self.filename = filename
+        if ident:
+            self.ident = ident
         if not self.filename:
             raise SourceError("No filename to load from")
 
@@ -155,7 +160,7 @@ class Source(deb822.Deb822):
         """ Create a name for this source. """
         uri = self.uris[0].replace('/', ' ')
         uri_list = uri.split()
-        name = '{}{}.sources'.format(
+        name = '{}{}'.format(
             prefix,
             '-'.join(uri_list[1:]).translate(util.CLEAN_CHARS)
         )
@@ -229,6 +234,30 @@ class Source(deb822.Deb822):
     @name.setter
     def name(self, name):
         self['X-Repolib-Name'] = name
+    
+    @property
+    def ident(self):
+        """str: a system-scope identifier for this source. Used for filename."""
+        try:
+            return self._ident
+        except AttributeError:
+            self._ident = None
+            return self._ident
+    
+    @ident.setter
+    def ident(self, ident):
+        self._ident = ident
+    
+    @property
+    def filename(self):
+        """str: The filename of the source."""
+        return f'{self.ident}.sources'
+    
+    @filename.setter
+    def filename(self, name):
+        name = name.replace('.list', '')
+        name = name.replace('.sources', '')
+        self._ident = name
 
     @property
     def enabled(self):

--- a/repolib/source_test.py
+++ b/repolib/source_test.py
@@ -31,7 +31,7 @@ from . import util
 
 class SourceTestCase(unittest.TestCase):
     def setUp(self):
-        self.source = source.Source(filename='test.source')
+        self.source = source.Source(ident='test')
         self.source.name = 'Test Source'
         self.source.enabled = False
         self.source.types = [util.AptSourceType.BINARY, util.AptSourceType.SOURCE]
@@ -64,7 +64,7 @@ class SourceTestCase(unittest.TestCase):
             'Architectures': 'amd64 armel',
             'Languages': 'en_US en_CA'
         })
-        self.assertEqual(self.source.filename, 'test.source')
+        self.assertEqual(self.source.filename, 'test.sources')
 
     def test_make_source_string(self):
         source_string = (

--- a/repolib/system.py
+++ b/repolib/system.py
@@ -42,7 +42,7 @@ class SystemSourceException(Exception):
 class SystemSource(source.Source):
     """ System Sources. """
 
-    def __init__(self, filename='system.sources'):
+    def __init__(self, ident='system'):
         """ Constructor for System Sources
 
         Loads a source object for the System Sources. These are located (by
@@ -50,7 +50,7 @@ class SystemSource(source.Source):
         a different location, please patch this in your packaging.
         """
         super().__init__()
-        self.load_from_file(filename=filename)
+        self.load_from_file(filename=self.filename)
 
     def set_component_enabled(self, component='main', enabled=True):
         """ Enables or disabled a repo component (e.g. 'main')

--- a/repolib/system.py
+++ b/repolib/system.py
@@ -50,7 +50,8 @@ class SystemSource(source.Source):
         a different location, please patch this in your packaging.
         """
         super().__init__()
-        self.load_from_file(filename=self.filename)
+        self.ident = ident
+        self.load_from_file()
 
     def set_component_enabled(self, component='main', enabled=True):
         """ Enables or disabled a repo component (e.g. 'main')


### PR DESCRIPTION
Since we know what type of file extension each type of source will have, we can build this into the file handling and not have to worry about it. If the name is specified on the incorrect type of source, it will fail because that filename will not exist.