### PR TITLE
System default mirror

### DIFF
--- a/.cz.toml
+++ b/.cz.toml
@@ -1,6 +1,6 @@
 [tool.commitizen]
 name = "cz_conventional_commits"
-version = "1.3.0"
+version = "1.4.0"
 tag_format = "$version"
 version_files = [
     'repolib/__version__.py:__version__'

--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,10 @@
+repolib (1.4.0) groovy; urgency=medium
+
+  * Added a new 'default-mirror' attribute to the system source
+    Allows Vendors to specify their recommended mirror
+
+ -- Ian Santopietro <ian@system76.com>  Wed, 14 Oct 2020 14:24:11 -0600
+
 repolib (1.3.0) focal; urgency=medium
 
   * New ident field for easier working with specific sources

--- a/docs/library/source/system.rst
+++ b/docs/library/source/system.rst
@@ -5,6 +5,26 @@ SystemSource()
 
 class repolib.SystemSource()
     A special :ref:`source-object` with its ``ident`` attribute pre-set to 
-    the path of the system software sources file. It is otherwise identical to 
-    the main :ref:`source-object` class.
+    the path of the system software sources file. It also contains a 
+    ``default_mirror`` attribute for storing the OS Vendor recommended mirror,
+    and a method to reset the current ``URIs`` to the given default.
+
+
+.. _system-default-mirror
+
+default_mirror
+==============
+
+Contains the OS Vendor's recommended default mirror for downloading software.
+
+
+.. _system-set-default-mirror
+
+set_default_mirror()
+====================
+
+repolib.SystemSource.set_default_mirror()
+    Sets the System Source URIs to the one in the :ref:`system-default-mirror`
+    attribute. Note that this does not save the source; you still need to call 
+    :ref:`save-to-disk` to save the changes.
     

--- a/repolib/__version__.py
+++ b/repolib/__version__.py
@@ -19,4 +19,4 @@ GNU Lesser General Public License for more details.
 You should have received a copy of the GNU Lesser General Public License
 along with RepoLib.  If not, see <https://www.gnu.org/licenses/>.
 """
-__version__ = "1.3.0"
+__version__ = "1.4.0"

--- a/repolib/command/modify.py
+++ b/repolib/command/modify.py
@@ -245,6 +245,11 @@ class Modify(command.Command):
     
     def default_mirror(self, value):
         """ Set the default mirror if this is the system source."""
+        if not value: 
+            # No value provided, take no action
+            return
+        self.count += 1
+
         if self.repo == 'system':
             self.source.default_mirror = value
 

--- a/repolib/command/modify.py
+++ b/repolib/command/modify.py
@@ -86,7 +86,8 @@ class Modify(command.Command):
         )
         modify_enable.add_argument(
             '--default-mirror',
-            help='Sets the default mirror for the system source.'
+            help=SUPPRESS
+            #help='Sets the default mirror for the system source.'
         )
 
         # Name

--- a/repolib/command/modify.py
+++ b/repolib/command/modify.py
@@ -243,10 +243,10 @@ class Modify(command.Command):
             return True
 
         return True
-    
+
     def default_mirror(self, value):
         """ Set the default mirror if this is the system source."""
-        if not value: 
+        if not value:
             # No value provided, take no action
             return
         self.count += 1

--- a/repolib/system.py
+++ b/repolib/system.py
@@ -106,3 +106,26 @@ class SystemSource(source.Source):
         raise SystemSourceException(
             msg=f"Couldn't toggle suite: {suite} to {enabled}"
         )
+    
+    def set_default_mirror(self):
+        """ Resets the System Sources to use the default mirrors.
+
+        Requires that the `default_mirror` attribute be set.
+        """
+        if self.default_mirror:
+            self.uris = [self.default_mirror]
+            return
+        raise SystemSourceException('No default mirror set.')
+
+    @property
+    def default_mirror(self):
+        """str: The default system mirror."""
+        try:
+            return self['X-Repolib-Default-Mirror']
+        except KeyError:
+            return ''
+    
+    @default_mirror.setter
+    def default_mirror(self, uri):
+        if util.url_validator(uri):
+            self['X-Repolib-Default-Mirror'] = uri

--- a/repolib/system.py
+++ b/repolib/system.py
@@ -106,7 +106,7 @@ class SystemSource(source.Source):
         raise SystemSourceException(
             msg=f"Couldn't toggle suite: {suite} to {enabled}"
         )
-    
+
     def set_default_mirror(self):
         """ Resets the System Sources to use the default mirrors.
 
@@ -124,7 +124,7 @@ class SystemSource(source.Source):
             return self['X-Repolib-Default-Mirror']
         except KeyError:
             return ''
-    
+
     @default_mirror.setter
     def default_mirror(self, uri):
         if util.url_validator(uri):

--- a/repolib/system.py
+++ b/repolib/system.py
@@ -19,7 +19,7 @@ GNU Lesser General Public License for more details.
 You should have received a copy of the GNU Lesser General Public License
 along with RepoLib.  If not, see <https://www.gnu.org/licenses/>.
 """
-#pylint: disable=too-many-ancestors
+#pylint: disable=too-many-ancestors, too-many-instance-attributes
 # If we want to use the subclass, we don't have a lot of options.
 
 from . import source


### PR DESCRIPTION
Adds a `default_mirror` attribute so that OS Vendors can save a recommended default mirror for the system source.

Required for pop-os/repoman#74. Requires #22 