### PR TITLE
Fix validation

### DIFF
--- a/repolib/legacy_deb.py
+++ b/repolib/legacy_deb.py
@@ -108,8 +108,8 @@ class LegacyDebSource(source.Source):
 
         if not self.name:
             self.make_names()
-            for source in self.sources:
-                source.name = self.name
+            for src in self.sources:
+                src.name = self.name
 
     def load_from_file(self, filename=None, ident=None):
         """ Loads the source from a file on disk.

--- a/repolib/legacy_deb.py
+++ b/repolib/legacy_deb.py
@@ -108,6 +108,8 @@ class LegacyDebSource(source.Source):
 
         if not self.name:
             self.make_names()
+            for source in self.sources:
+                source.name = self.name
 
     def load_from_file(self, filename=None, ident=None):
         """ Loads the source from a file on disk.
@@ -120,17 +122,18 @@ class LegacyDebSource(source.Source):
         name = None
 
         full_path = util.get_sources_dir() / self.filename
-
+        sources = []
         with open(full_path, 'r') as source_file:
             for line in source_file:
                 if util.validate_debline(line):
                     deb_src = deb.DebLine(line)
-                    self.sources.append(deb_src)
                     deb_src.name = self.name
+                    sources.append(deb_src)
                 elif "X-Repolib-Name" in line:
                     name = ':'.join(line.split(':')[1:])
                     self.name = name.strip()
 
+        self.sources = sources
         self.load_from_sources()
 
     # pylint: disable=arguments-differ

--- a/repolib/legacy_deb_test.py
+++ b/repolib/legacy_deb_test.py
@@ -54,7 +54,7 @@ class LegacyTestCase(unittest.TestCase):
             )
         self.source = legacy_deb.LegacyDebSource(ident='test')
         self.source.load_from_file()
-    
+
     def test_no_suites(self):
         opts = {'Trusted': 'yes'}
         types = [util.AptSourceType.BINARY, util.AptSourceType.SOURCE]

--- a/repolib/legacy_deb_test.py
+++ b/repolib/legacy_deb_test.py
@@ -44,8 +44,30 @@ class LegacyTestCase(unittest.TestCase):
                 'deb [arch=armel,amd64 lang=en_US] http://example.com ubuntu main\n'
                 'deb-src [arch=armel,amd64 lang=en_US] http://example.com ubuntu main\n'
             )
+        with open(util.get_sources_dir(testing=True) / 'test3.list', mode='w') as test_file:
+            test_file.write(
+                '## Added/managed by repolib ##\n'
+                '#\n'
+                '## X-Repolib-Name: test no suites\n'
+                'deb [trusted=yes] file:///var/cache/apt/archives ./\n'
+                'deb-src [trusted=yes] file:///var/cache/apt/archives ./\n'
+            )
         self.source = legacy_deb.LegacyDebSource(ident='test')
         self.source.load_from_file()
+    
+    def test_no_suites(self):
+        opts = {'Trusted': 'yes'}
+        types = [util.AptSourceType.BINARY, util.AptSourceType.SOURCE]
+        source = legacy_deb.LegacyDebSource(ident='test3')
+        source.load_from_file()
+
+        self.assertEqual(source.ident, 'test3')
+        self.assertEqual(source.name, 'test no suites')
+        self.assertEqual(source.types, types)
+        self.assertEqual(source.uris, ['file:///var/cache/apt/archives'])
+        self.assertEqual(source.suites, ['./'])
+        self.assertFalse(source.components)
+        self.assertDictEqual(source.options, opts)
 
     def test_load_from_file(self):
         opts = {'Architectures': 'amd64'}
@@ -73,8 +95,10 @@ class LegacyTestCase(unittest.TestCase):
         testline4 = 'deb-src http://example.com ubuntu main'
         testline5 = '# dbe http://example.com ubuntu main'
         testline6 = 'dba http://example.com ubuntu main'
+        testline7 = 'deb file:///var/cache/apt/archives ./'
+        testline8 = 'deb [trusted=yes] file:///var/cache/apt/archives ./'
 
-        for line in [testline1, testline2, testline3, testline4]:
+        for line in [testline1, testline2, testline3, testline4, testline7, testline8]:
             self.assertTrue(util.validate_debline(line))
 
         for line in [testline5, testline6]:

--- a/repolib/source.py
+++ b/repolib/source.py
@@ -56,7 +56,15 @@ class Source(deb822.Deb822):
         'lang': 'Languages',
         'target': 'Targets',
         'pdiffs': 'PDiffs',
-        'by-hash': 'By-Hash'
+        'by-hash': 'By-Hash',
+        'allow-insecure': 'Allow-Insecure',
+        'allow-weak': 'Allow-Weak',
+        'allow-downgrade-to-insecure': 'Allow-Downgrade-To-Insecure',
+        'trusted': 'Trusted',
+        'signed-by': 'Signed-By',
+        'check-valid-until': 'Check-Valid-Until',
+        'valid-until-min': 'Valid-Until-Min',
+        'valid-until-max': 'Valid-Until-Max'
     }
 
     outoptions_d = {
@@ -64,7 +72,15 @@ class Source(deb822.Deb822):
         'Languages': 'lang',
         'Targets': 'target',
         'PDiffs': 'pdiffs',
-        'By-Hash': 'by-hash'
+        'By-Hash': 'by-hash',
+        'Allow-Insecure': 'allow-insecure',
+        'Allow-Weak': 'allow-weak',
+        'Allow-Downgrade-To-Insecure': 'allow-downgrade-to-insecure',
+        'Trusted': 'trusted',
+        'Signed-By': 'signed-by',
+        'Check-Valid-Until': 'check-valid-until',
+        'Valid-Until-Min': 'valid-until-min',
+        'Valid-Until-Max': 'valid-until-max'
     }
     options_re = re.compile(r'[^@.+]\[([^[]+.+)\]\ ')
     uri_re = re.compile(r'\w+:(\/?\/?)[^\s]+')

--- a/repolib/util.py
+++ b/repolib/util.py
@@ -168,6 +168,8 @@ def get_sources_dir(testing=False):
     sources_dir.mkdir(parents=True, exist_ok=True)
     return sources_dir
 
+# pylint: disable=inconsistent-return-statements
+# This is a better way to check these
 def validate_debline(valid):
     """ Basic checks to see if a given debline is valid or not.
 

--- a/repolib/util.py
+++ b/repolib/util.py
@@ -110,6 +110,10 @@ def url_validator(url):
         # A) We want to return false if the URL doesn't contain those parts
         # B) We need this to not throw any exceptions, regardless what they are
         result = urlparse(url)
+        if not result.scheme:
+            return False
+        if result.scheme == 'x-repolib-name':
+            return False
         if result.netloc:
             # We need at least a scheme and a netlocation/hostname or...
             return all([result.scheme, result.netloc])
@@ -178,17 +182,16 @@ def validate_debline(valid):
         valid = valid.strip()
 
     if valid.startswith("deb"):
-        if "http" in valid:
-            return True
+        words = valid.split()
+        for word in words:
+            if url_validator(word):
+                return True
 
     elif valid.startswith("ppa:"):
         if "/" in valid:
             return True
 
-    elif valid.startswith("http"):
-        if "://" in valid:
-            if valid.endswith('.flatpakrepo'):
-                return False
-            return True
-
-    return False
+    else:
+        if valid.endswith('.flatpakrepo'):
+            return False
+        return url_validator(valid)


### PR DESCRIPTION
There were several issues related to various Validations in Repolib

* Repolib did not allow valid file:/// URIs in .list files in sources.list.d
* Repolib URL validation had some serious issues in its ability to parse URLs, allowing invalid URLs
* Repolib Deb Line validation allows invalid deblines, while failing valid lines.
* Repolib did not support several options which were documented and supported upstream by Debian.
* Repolib was missing tests for repos under these conditions

This PR fixes these validation issues. Thanks to @ahoneybun for finding these issues!

Fixes #25 