### PR TITLE
Better error handling and reporting

### DIFF
--- a/docs/aptmanage/list.rst
+++ b/docs/aptmanage/list.rst
@@ -66,7 +66,10 @@ Note
 
 Passing the ``--verbose`` flag only applies to listing all sources. It has no 
 effect if a source is specified using the system-identifier; in that case, only 
-the specified source is printed.
+the specified source is printed. Additionally, if there are sources files which 
+contain errors, the ``--verbose`` flag will print details about them, including 
+the contents of the files and the stack trace of the exception which caused the 
+error.
 
 
 Legacy sources.list entries

--- a/docs/library/developer.rst
+++ b/docs/library/developer.rst
@@ -47,10 +47,25 @@ repolib.VERSION
 get_all_sources()
 -----------------
 
-repolib.get_all_sources(get_system=False)
-    Returns a ``list`` of all configured sources currently on the system. If 
-    ```get_system`` (default: ``False``) is ``True``, then the system source (if 
-    configured and detected) will be included as the first item in the list.
+repolib.get_all_sources(get_system=False, get_exceptions=False)
+    Get a list of all valid sources configured on the system. Invalid sources or 
+    sources with formatting errors are excluded.
+
+    Returns:
+        Either a ``list`` of :ref:`source-object`, or a tuple with this list 
+        plus a :obj:`dict` with :obj:`Exception` for any sources with errors 
+
+get_system
+^^^^^^^^^^
+:obj:`bool` - Whether to include the system source at the beginning of the list
+of sources.
+
+get_exceptions
+^^^^^^^^^^^^^^
+:obj:`bool` - Whether to return just the list of sources or to include the 
+exception Dictionary. If ``True``, then the Exception Dictionary will contain 
+keys for each failing filename, plus the :obj:`Exception` which triggered the 
+failure.
 
 
 Example

--- a/repolib/__init__.py
+++ b/repolib/__init__.py
@@ -55,27 +55,25 @@ def get_all_sources(get_system=False, pass_exceptions=False):
     for file in sources_files:
         if file.stem == 'system':
             continue
-        source = Source(filename=file.stem)
+        source = Source(filename=file.name)
         try:
             source.load_from_file()
         except Exception as err:
-            print(f'ERROR: Could not process source {file.name}')
-            print(f'Error details: \n{err}')
-            if pass_exceptions:
-                raise err
+            errors[file.stem] = err
         else:
             sources.append(source)
 
     for file in list_files:
-        source = LegacyDebSource(filename=file.stem)
+        source = LegacyDebSource(filename=file.name)
         try:
             source.load_from_file()
         except Exception as err:
-            print(f'ERROR: Could not process source {file.name}')
-            print(f'Error details: \n{err}')
-            if pass_exceptions:
-                raise err
+            errors[file.stem] = err
         else:
             sources.append(source)
 
-    return sources
+    if pass_exceptions:
+        for error in errors:
+            raise errors[error]
+
+    return sources, errors

--- a/repolib/__init__.py
+++ b/repolib/__init__.py
@@ -41,7 +41,7 @@ def get_all_sources(get_system=False, get_exceptions=False):
     Arguments:
         get_system (bool): Whether to include the system repository or not.
         get_exceptions (bool): Whether to return information about failures.
-    
+
     Returns:
         Without `get_exceptions`, return the :obj:`list` of :obj:`Source`
         With `get_exceptions`, return: (

--- a/repolib/__init__.py
+++ b/repolib/__init__.py
@@ -35,7 +35,7 @@ VERSION = __version__.__version__
 # pylint: disable=broad-except
 # We want to be broad in catching exceptions here, as failure could mean
 # applications unexpectedly close
-def get_all_sources(get_system=False, exit_on_failure=False):
+def get_all_sources(get_system=False, pass_exceptions=False):
     """ Returns a list of all the sources on the system.
 
     Arguments:
@@ -46,6 +46,7 @@ def get_all_sources(get_system=False, exit_on_failure=False):
     list_files = sources_path.glob('*.list')
 
     sources = []
+    errors = {}
 
     if get_system:
         source = SystemSource()
@@ -60,9 +61,10 @@ def get_all_sources(get_system=False, exit_on_failure=False):
         except Exception as err:
             print(f'ERROR: Could not process source {file.name}')
             print(f'Error details: \n{err}')
-            if exit_on_failure:
+            if pass_exceptions:
                 raise err
-        sources.append(source)
+        else:
+            sources.append(source)
 
     for file in list_files:
         source = LegacyDebSource(filename=file.stem)
@@ -71,8 +73,9 @@ def get_all_sources(get_system=False, exit_on_failure=False):
         except Exception as err:
             print(f'ERROR: Could not process source {file.name}')
             print(f'Error details: \n{err}')
-            if exit_on_failure:
+            if pass_exceptions:
                 raise err
-        sources.append(source)
+        else:
+            sources.append(source)
 
     return sources

--- a/repolib/__init__.py
+++ b/repolib/__init__.py
@@ -40,6 +40,14 @@ def get_all_sources(get_system=False, get_exceptions=False):
 
     Arguments:
         get_system (bool): Whether to include the system repository or not.
+        get_exceptions (bool): Whether to return information about failures.
+    
+    Returns:
+        Without `get_exceptions`, return the :obj:`list` of :obj:`Source`
+        With `get_exceptions`, return: (
+            :obj:`list` of :obj:`Source`,
+            :obj:`dict` of :obj:`Exception`
+        )
     """
     sources_path = util.get_sources_dir()
     sources_files = sources_path.glob('*.sources')

--- a/repolib/__init__.py
+++ b/repolib/__init__.py
@@ -32,7 +32,7 @@ from . import __version__
 
 VERSION = __version__.__version__
 
-def get_all_sources(get_system=False):
+def get_all_sources(get_system=False, exit_on_failure=False):
     """ Returns a list of all the sources on the system.
 
     Arguments:
@@ -52,12 +52,20 @@ def get_all_sources(get_system=False):
         if file.stem == 'system':
             continue
         source = Source(filename=file.stem)
-        source.load_from_file()
+        try:
+            source.load_from_file()
+        except Exception as e:
+            print(f'ERROR: Could not process source {file.name}')
+            print(f'Error details: \n{e}')
         sources.append(source)
 
     for file in list_files:
         source = LegacyDebSource(filename=file.stem)
-        source.load_from_file()
+        try:
+            source.load_from_file()
+        except Exception as e:
+            print(f'ERROR: Could not process source {file.name}')
+            print(f'Error details: \n{e}')
         sources.append(source)
 
     return sources

--- a/repolib/__init__.py
+++ b/repolib/__init__.py
@@ -32,6 +32,9 @@ from . import __version__
 
 VERSION = __version__.__version__
 
+# pylint: disable=broad-except
+# We want to be broad in catching exceptions here, as failure could mean
+# applications unexpectedly close
 def get_all_sources(get_system=False, exit_on_failure=False):
     """ Returns a list of all the sources on the system.
 
@@ -54,18 +57,22 @@ def get_all_sources(get_system=False, exit_on_failure=False):
         source = Source(filename=file.stem)
         try:
             source.load_from_file()
-        except Exception as e:
+        except Exception as err:
             print(f'ERROR: Could not process source {file.name}')
-            print(f'Error details: \n{e}')
+            print(f'Error details: \n{err}')
+            if exit_on_failure:
+                raise err
         sources.append(source)
 
     for file in list_files:
         source = LegacyDebSource(filename=file.stem)
         try:
             source.load_from_file()
-        except Exception as e:
+        except Exception as err:
             print(f'ERROR: Could not process source {file.name}')
-            print(f'Error details: \n{e}')
+            print(f'Error details: \n{err}')
+            if exit_on_failure:
+                raise err
         sources.append(source)
 
     return sources

--- a/repolib/__init__.py
+++ b/repolib/__init__.py
@@ -35,7 +35,7 @@ VERSION = __version__.__version__
 # pylint: disable=broad-except
 # We want to be broad in catching exceptions here, as failure could mean
 # applications unexpectedly close
-def get_all_sources(get_system=False, pass_exceptions=False):
+def get_all_sources(get_system=False, get_exceptions=False):
     """ Returns a list of all the sources on the system.
 
     Arguments:
@@ -68,12 +68,10 @@ def get_all_sources(get_system=False, pass_exceptions=False):
         try:
             source.load_from_file()
         except Exception as err:
-            errors[file.stem] = err
+            errors[file] = err
         else:
             sources.append(source)
 
-    if pass_exceptions:
-        for error in errors:
-            raise errors[error]
-
-    return sources, errors
+    if get_exceptions:
+        return sources, errors
+    return sources

--- a/repolib/command/list.py
+++ b/repolib/command/list.py
@@ -105,7 +105,7 @@ class List(command.Command):
 
         if not self.no_names:
             print('Configured sources:')
-        for source in get_all_sources(get_system=True):
+        for source in get_all_sources(get_system=True, pass_exceptions=self.verbose):
             self.log.debug('Found source file %s', source.filename)
             if self.no_names:
                 print(f'{source.ident}')

--- a/repolib/command/list.py
+++ b/repolib/command/list.py
@@ -107,9 +107,9 @@ class List(command.Command):
 
         if not self.no_names:
             print('Configured sources:')
-        
+
         sources, errors = get_all_sources(get_system=True, get_exceptions=True)
-        
+
         for source in sources:
             self.log.debug('Found source file %s', source.filename)
             if self.no_names:


### PR DESCRIPTION
Adds exception handling to the `get_all_sources()` function. Expands the `get_all_sources()` function to optionally fetch information about source files with errors and return them along with any exceptions which caused errors parsing them. 

This will enable error dialogs in Repoman in the cases of issues like #25 , and enables these features for `apt-manage`. 