### PR TITLE
Better handling of empty files

### DIFF
--- a/.cz.toml
+++ b/.cz.toml
@@ -1,6 +1,6 @@
 [tool.commitizen]
 name = "cz_conventional_commits"
-version = "1.4.0"
+version = "1.5.0"
 tag_format = "$version"
 version_files = [
     'repolib/__version__.py:__version__'

--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,22 @@
+repolib (1.5.0) groovy; urgency=medium
+
+  * Empty sources (without URIs or Suites, legacy sources without consituent
+    lines) are not shown in the list and aren't included in the list
+    via get_all_sources()
+  * Empty sources always report they are not Enabled.
+  * Empty sources cannot be set to Enabled.
+  * Empty sources do not throw exceptions
+  * Empty sources can have modifications made to them (making them        
+    no-longer empty). 
+  * Non-empty sources can have all URIs and Suites removed (making
+    them empty).
+  * URI Validation has been improved.
+  * Fault-tolerance is greatly improved
+  * apt-manage: files with syntax errors are displayed in output
+  * apt-manage: debug output includes contents of invalid files
+
+ -- Ian Santopietro <ian@system76.com>  Thu, 29 Oct 2020 15:33:04 -0600
+
 repolib (1.4.0) groovy; urgency=medium
 
   * Added a new 'default-mirror' attribute to the system source

--- a/repolib/__init__.py
+++ b/repolib/__init__.py
@@ -69,7 +69,11 @@ def get_all_sources(get_system=False, get_exceptions=False):
         except Exception as err:
             errors[file.stem] = err
         else:
-            sources.append(source)
+            # The source should not be listed if it is empty
+            has_uris = len(source.uris) > 0
+            has_suites = len(source.suites) > 0
+            if has_uris and has_suites:
+                sources.append(source)
 
     for file in list_files:
         source = LegacyDebSource(filename=file.name)
@@ -78,7 +82,11 @@ def get_all_sources(get_system=False, get_exceptions=False):
         except Exception as err:
             errors[file] = err
         else:
-            sources.append(source)
+            # The source should not be listed if it is empty
+            has_uris = len(source.uris) > 0
+            has_suites = len(source.suites) > 0
+            if has_uris and has_suites:
+                sources.append(source)
 
     if get_exceptions:
         return sources, errors

--- a/repolib/__version__.py
+++ b/repolib/__version__.py
@@ -19,4 +19,4 @@ GNU Lesser General Public License for more details.
 You should have received a copy of the GNU Lesser General Public License
 along with RepoLib.  If not, see <https://www.gnu.org/licenses/>.
 """
-__version__ = "1.4.0"
+__version__ = "1.5.0"

--- a/repolib/legacy_deb.py
+++ b/repolib/legacy_deb.py
@@ -92,20 +92,18 @@ class LegacyDebSource(source.Source):
         components = []
         options = {}
 
-        # If the file is empty or contains no valid sources, skip it.
-        if len(self.sources) > 0:
-            for repo in self.sources:
-                if repo.types[0] not in self.types:
-                    self.types.append(repo.types[0])
-                if repo.enabled.value == 'yes':
-                    if util.AptSourceType.BINARY in repo.types:
-                        enabled = True
-                    else:
-                        self.source_code_enabled = True
-                uris = combine_lists(uris, repo.uris)
-                suites = combine_lists(suites, repo.suites)
-                components = combine_lists(components, repo.components)
-                options.update(repo.options)
+        for repo in self.sources:
+            if repo.types[0] not in self.types:
+                self.types.append(repo.types[0])
+            if repo.enabled.value == 'yes':
+                if util.AptSourceType.BINARY in repo.types:
+                    enabled = True
+                else:
+                    self.source_code_enabled = True
+            uris = combine_lists(uris, repo.uris)
+            suites = combine_lists(suites, repo.suites)
+            components = combine_lists(components, repo.components)
+            options.update(repo.options)
 
         self.uris = uris.copy()
         self.suites = suites.copy()

--- a/repolib/legacy_deb.py
+++ b/repolib/legacy_deb.py
@@ -82,6 +82,10 @@ class LegacyDebSource(source.Source):
 
     def load_from_sources(self):
         """ Loads the source from its consituent source lines."""
+        # If the file is empty or contains no valid sources, skip it.
+        if len(self.sources) <= 0:
+            return 
+
         enabled = False
         uris = []
         suites = []
@@ -135,6 +139,7 @@ class LegacyDebSource(source.Source):
 
         self.sources = sources
         self.load_from_sources()
+
 
     # pylint: disable=arguments-differ
     # This is operating on a very different kind of source, thus needs to be

--- a/repolib/source.py
+++ b/repolib/source.py
@@ -171,12 +171,17 @@ class Source(deb822.Deb822):
 
     def make_name(self, prefix=''):
         """ Create a name for this source. """
-        uri = self.uris[0].replace('/', ' ')
-        uri_list = uri.split()
-        name = '{}{}'.format(
-            prefix,
-            '-'.join(uri_list[1:]).translate(util.CLEAN_CHARS)
-        )
+        if len(self.uris) > 0:
+            uri = self.uris[0].replace('/', ' ')
+            uri_list = uri.split()
+            name = '{}{}'.format(
+                prefix,
+                '-'.join(uri_list[1:]).translate(util.CLEAN_CHARS)
+            )
+        else:
+            # Use the ident as a fallback as it should be good enough
+            name = self.ident
+
         return name
 
     def init_values(self):

--- a/repolib/source.py
+++ b/repolib/source.py
@@ -132,6 +132,12 @@ class Source(deb822.Deb822):
         Returns:
             A str which can be printed to console.
         """
+        # The source can't be enabled if there are no uris or suites
+        no_uris = len(self.uris) <= 0
+        no_suites = len(self.suites) <= 0
+        if no_uris or no_suites:
+            self.enabled = False
+
         if not self.name:
             self.name = self.filename.replace('.sources', '')
 
@@ -291,6 +297,12 @@ class Source(deb822.Deb822):
     @property
     def enabled(self):
         """ util.AptSourceEnabled: Whether the source is enabled or not. """
+        # The source can't be enabled if there are no uris or suites
+        no_uris = len(self.uris) <= 0
+        no_suites = len(self.suites) <= 0
+        if no_uris or no_suites:
+            return util.AptSourceEnabled.FALSE
+
         try:
             return util.AptSourceEnabled(self['enabled'])
         except KeyError:


### PR DESCRIPTION
Improves the way Repolib handles empty source files  (without URIs or Suites, legacy sources without constituent lines):

 * Empty sources are not shown in the list and aren't included in the list
   via get_all_sources()
 * Empty sources always report they are not Enabled.
 * Empty sources cannot be set to Enabled.
 * Empty sources do not throw exceptions
 * Empty sources can have modifications made to them (making them        
   no-longer empty). 
 * Non-empty sources can have all URIs and Suites removed (making
   them empty).

Fixes #27 