### PR TITLE
refactor(util): replace lsb_release module with distro

### DIFF
--- a/debian/control
+++ b/debian/control
@@ -4,10 +4,10 @@ Priority: optional
 Maintainer: Ian Santopietro <isantop@gmail.com>
 Build-Depends: debhelper (>= 11),
                dh-python,
-               lsb-release,
                python3-all,
                python3-dbus,
                python3-debian,
+               python3-distro,
                python3-setuptools,
                python3-distutils,
                python3-pytest

--- a/repolib/util.py
+++ b/repolib/util.py
@@ -40,8 +40,8 @@ class RepoError(Exception):
         self.code = code
 
 try:
-    import lsb_release
-    DISTRO_CODENAME = lsb_release.get_distro_information()['CODENAME']
+    import distro
+    DISTRO_CODENAME = distro.codename()
 except ImportError:
     DISTRO_CODENAME = 'linux'
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,4 @@
+dbus-python
+distro
 pytest-pylint
 python-debian
-dbus-python


### PR DESCRIPTION
Python3's distro module is included in most distros already and much simpler to work with than lsb_release.

This replaces our limited use of lsb_release with distro for better future maintainability.