### PR TITLE
fix: preserve comments in list files

### DIFF
--- a/.cz.toml
+++ b/.cz.toml
@@ -1,6 +1,6 @@
 [tool.commitizen]
 name = "cz_conventional_commits"
-version = "1.5.0"
+version = "1.5.1"
 tag_format = "$version"
 version_files = [
     'repolib/__version__.py:__version__'

--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,9 @@
+repolib (1.5.1) groovy; urgency=medium
+
+  * Comments in list files are now preserved
+
+ -- Ian Santopietro <ian@system76.com>  Tue, 17 Nov 2020 11:43:25 -0700
+
 repolib (1.5.0) groovy; urgency=medium
 
   * Empty sources (without URIs or Suites, legacy sources without consituent

--- a/repolib/__version__.py
+++ b/repolib/__version__.py
@@ -19,4 +19,4 @@ GNU Lesser General Public License for more details.
 You should have received a copy of the GNU Lesser General Public License
 along with RepoLib.  If not, see <https://www.gnu.org/licenses/>.
 """
-__version__ = "1.5.0"
+__version__ = "1.5.1"

--- a/repolib/legacy_deb.py
+++ b/repolib/legacy_deb.py
@@ -147,7 +147,7 @@ class LegacyDebSource(source.Source):
 
         # self.comment = self.comment.strip()
         if not self.comment:
-            self.comment = '## Added/managed by repolib ##\n#'
+            self.comment = '## Added/managed by repolib ##\n#\n'
 
         self.sources = sources
         self.load_from_sources()
@@ -186,7 +186,7 @@ class LegacyDebSource(source.Source):
             if line and not line.startswith('#'):
                 line = f'#{line}'
         toprint = '\n'.join(comment)
-        toprint += f'\n## X-Repolib-Name: {self.name}\n'
+        toprint += f'## X-Repolib-Name: {self.name}\n'
 
         for suite in self.suites:
             for uri in self.uris:

--- a/repolib/legacy_deb.py
+++ b/repolib/legacy_deb.py
@@ -129,15 +129,25 @@ class LegacyDebSource(source.Source):
 
         full_path = util.get_sources_dir() / self.filename
         sources = []
+        self.comment = ''
         with open(full_path, 'r') as source_file:
             for line in source_file:
+                name_line = 'X-Repolib-Name' in line
                 if util.validate_debline(line):
                     deb_src = deb.DebLine(line)
                     deb_src.name = self.name
                     sources.append(deb_src)
-                elif "X-Repolib-Name" in line:
+                elif name_line:
                     name = ':'.join(line.split(':')[1:])
                     self.name = name.strip()
+                elif line.startswith('#') and not name_line:
+                    self.comment += f'{line}'
+                elif line == '\n':
+                    self.comment += '\n'
+
+        # self.comment = self.comment.strip()
+        if not self.comment:
+            self.comment = '## Added/managed by repolib ##\n#'
 
         self.sources = sources
         self.load_from_sources()
@@ -171,8 +181,12 @@ class LegacyDebSource(source.Source):
         Returns:
             A str with the output entries.
         """
-        toprint = '## Added/managed by repolib ##\n'
-        toprint += f'#\n## X-Repolib-Name: {self.name}\n'
+        comment = self.comment.split('\n')
+        for line in comment:
+            if line and not line.startswith('#'):
+                line = f'#{line}'
+        toprint = '\n'.join(comment)
+        toprint += f'\n## X-Repolib-Name: {self.name}\n'
 
         for suite in self.suites:
             for uri in self.uris:

--- a/repolib/source.py
+++ b/repolib/source.py
@@ -92,6 +92,8 @@ class Source(deb822.Deb822):
         if ident:
             self.ident = ident
 
+        self.comment = '## Added/managed by repolib ##\n#'
+
     def load_from_file(self, filename=None, ident=None):
         """ Loads the data from a file path.
 

--- a/repolib/source.py
+++ b/repolib/source.py
@@ -92,7 +92,7 @@ class Source(deb822.Deb822):
         if ident:
             self.ident = ident
 
-        self.comment = '## Added/managed by repolib ##\n#'
+        self.comment = '## Added/managed by repolib ##\n#\n'
 
     def load_from_file(self, filename=None, ident=None):
         """ Loads the data from a file path.

--- a/repolib/util.py
+++ b/repolib/util.py
@@ -196,4 +196,6 @@ def validate_debline(valid):
     else:
         if valid.endswith('.flatpakrepo'):
             return False
-        return url_validator(valid)
+        if len(valid.split()) == 1:
+            return url_validator(valid)
+        return False


### PR DESCRIPTION
List files can contain comments which may be added by third-party developers to help explain context or purpose behind a particular repository. A good example of this is in teamviewer (see #32).

This change causes comments at the beginning of list files to be preserved when a file is modified by Repolib. Previously, these comments were lost, which may present problems for some users who may rely on the information in these comments. 

There is also a small fix for the deb validator, which causes it to skip comment lines that have spaces, since these cannot be a valid URL. This was causing a bug with some comment lines, as they looked like a URL to the parser but actually merely contained colon characters.

Fixes #32