### PR TITLE
Key management

### DIFF
--- a/data/service.py
+++ b/data/service.py
@@ -19,6 +19,8 @@
 '''
 #pylint: skip-file
 
+import subprocess
+
 import gi
 from gi.repository import GObject, GLib
 
@@ -55,6 +57,22 @@ class Repo(dbus.service.Object):
         
         self.source = None
         self.sources_dir = Path('/etc/apt/sources.list.d')
+    
+    @dbus.service.method(
+        "org.pop_os.repolib.Interface",
+        in_signature='as', out_signature='',
+        sender_keyword='sender', connection_keyword='conn'
+    )
+    def add_apt_signing_key(self, cmd, sender=None, conn=None):
+        self._check_polkit_privilege(
+            sender, conn, 'org.pop_os.repolib.modifysources'
+        )
+        key = cmd.pop(-1)
+        key = key.encode()
+        try:
+            subprocess.run(cmd, check=True, input=key)
+        except subprocess.CalledProcessError as e:
+            raise e
     
     @dbus.service.method(
         "org.pop_os.repolib.Interface",

--- a/data/service.py
+++ b/data/service.py
@@ -67,12 +67,13 @@ class Repo(dbus.service.Object):
         self._check_polkit_privilege(
             sender, conn, 'org.pop_os.repolib.modifysources'
         )
-        key = cmd.pop(-1)
-        key = key.encode()
-        try:
-            subprocess.run(cmd, check=True, input=key)
-        except subprocess.CalledProcessError as e:
-            raise e
+        print(cmd)
+        key_path = str(cmd.pop(-1))
+        with open(key_path, mode='wb') as keyfile:
+            try:
+                subprocess.run(cmd, check=True, stdout=keyfile)
+            except subprocess.CalledProcessError as e:
+                raise e
     
     @dbus.service.method(
         "org.pop_os.repolib.Interface",

--- a/data/service.py
+++ b/data/service.py
@@ -57,6 +57,7 @@ class Repo(dbus.service.Object):
         
         self.source = None
         self.sources_dir = Path('/etc/apt/sources.list.d')
+        self.keys_dir = Path('/etc/apt/trusted.gpg.d')
     
     @dbus.service.method(
         "org.pop_os.repolib.Interface",
@@ -90,14 +91,19 @@ class Repo(dbus.service.Object):
 
     @dbus.service.method(
         "org.pop_os.repolib.Interface",
-        in_signature='s', out_signature='',
+        in_signature='ss', out_signature='',
         sender_keyword='sender', connection_keyword='conn'
     )
-    def delete_source(self, filename, sender=None, conn=None):
+    def delete_source(self, filename, key_filename, sender=None, conn=None):
         self._check_polkit_privilege(
             sender, conn, 'org.pop_os.repolib.modifysources'
         )
+        key_file = self.keys_dir /key_filename
         source_file = self.sources_dir / filename
+        try:
+            key_file.unlink()
+        except FileNotFoundError:
+            pass
         source_file.unlink()
 
     @dbus.service.method(

--- a/debian/control
+++ b/debian/control
@@ -8,6 +8,8 @@ Build-Depends: debhelper (>= 11),
                python3-dbus,
                python3-debian,
                python3-distro,
+               python3-lazr.restfulclient,
+               python3-launchpadlib,
                python3-setuptools,
                python3-distutils,
                python3-pytest
@@ -25,6 +27,8 @@ Depends: ${python3:Depends},
          lsb-release,
          python3-dbus,
          python3-debian
+Recommends: python3-lazr.restfulclient,
+            python3-launchpadlib
 Description: Repository Management for APT in Python (Python 3)
  RepoLib is a Python library and CLI tool-set for managing your software
  system software repositories. It's currently set up to handle APT repositories

--- a/repolib/command/add.py
+++ b/repolib/command/add.py
@@ -143,7 +143,6 @@ class Add(command.Command):
         """ Run the command."""
         # pylint: disable=too-many-branches
         # We just need all these different checks.
-
         debline = ' '.join(self.args.deb_line)
         if self.args.deb_line == '822styledeb':
             self.parser.print_usage()
@@ -152,6 +151,8 @@ class Add(command.Command):
 
         if debline.startswith('http') and len(debline.split()) == 1:
             debline = f'deb {debline} {DISTRO_CODENAME} main'
+
+        print('Fetching repository information...')
 
         new_source = LegacyDebSource()
         if debline.startswith('ppa:'):
@@ -206,12 +207,15 @@ class Add(command.Command):
 
         if self.expand:
             print(new_source.sources[0].make_source_string())
-            print(f'{add_source.ppa_info["description"]}\n')
+            try:
+                print(f'{add_source.ppa.description}\n')
+            except AttributeError:
+                pass
             print('Press [ENTER] to contine or Ctrl + C to cancel.')
             input()
 
         if not self.skip_keys:
-            add_source.add_ppa_key(debug=self.debug, log=self.log)
+            add_source.add_ppa_key(add_source, debug=self.debug, log=self.log)
             
         if self.args.debug == 0:
             new_source.save_to_disk()

--- a/repolib/command/add.py
+++ b/repolib/command/add.py
@@ -21,12 +21,11 @@ along with RepoLib.  If not, see <https://www.gnu.org/licenses/>.
 
 Module for adding repos to the system in CLI applications.
 """
-import tempfile
 
 from ..deb import DebLine
 from ..legacy_deb import LegacyDebSource
 from ..ppa import PPALine
-from ..util import DISTRO_CODENAME, CLEAN_CHARS, fetch_key
+from ..util import DISTRO_CODENAME, CLEAN_CHARS
 
 from . import command
 
@@ -98,12 +97,6 @@ class Add(command.Command):
             help='Skip adding signing keys (not recommended!)'
         )
 
-    # pylint: disable=too-few-public-methods
-    # Thinking of ways to add more, but otherwise this is just simple.
-
-    def __init__(self, log, args, parser):
-        super().__init__(log, args, parser)
-    
     def finalize_options(self, args):
         """ Finish setting up options/arguments."""
         super().finalize_options(args)
@@ -139,6 +132,8 @@ class Add(command.Command):
             self.log.debug('Got Ident: %s', self.ident)
             source.ident = self.ident.lower()
 
+# pylint: disable=too-many-statements, attribute-defined-outside-init
+# Not a lot of reusable code here. Unfortunately it just needs to do a lot.
     def run(self):
         """ Run the command."""
         # pylint: disable=too-many-branches
@@ -216,7 +211,7 @@ class Add(command.Command):
 
         if not self.skip_keys:
             add_source.add_ppa_key(add_source, debug=self.debug, log=self.log)
-            
+
         if self.args.debug == 0:
             new_source.save_to_disk()
             return True

--- a/repolib/command/modify.py
+++ b/repolib/command/modify.py
@@ -161,19 +161,11 @@ class Modify(command.Command):
             '--add-option',
             metavar='OPTION=VALUE[,OPTION=VALUE]',
             help=SUPPRESS
-            # help=(
-            #     'Add the specified option(s) and value(s) to the repository. '
-            #     'Multiple option-value pairs should be separated with commas.'
-            # )
         )
         parser.add_argument(
             '--remove-option',
             metavar='OPTION=VALUE[,OPTION=VALUE]',
             help=SUPPRESS
-            # help=(
-            #     'Remove the specified option(s) and value(s) from the repository. '
-            #     'Multiple option-value pairs should be separated with commas.'
-            # )
         )
 
     def __init__(self, log, args, parser):

--- a/repolib/command/remove.py
+++ b/repolib/command/remove.py
@@ -116,7 +116,7 @@ class Remove(command.Command):
                 'No source %s found on system. Check the spelling.', self.source
             )
             return False
-            
+
         key_file = remove_source.key_file
 
         if self.assume_yes:

--- a/repolib/ppa.py
+++ b/repolib/ppa.py
@@ -318,35 +318,3 @@ def get_info_from_lp(owner_name, ppa):
     """
     ppa = PPA(owner_name, ppa)
     return ppa
-
-# def add_key(source, fingerprint, debug=False, log=None):
-#     """ Add a signing key for the source.
-
-#     Arguments: 
-#         :Source source: The source whose key to add.
-#         :str fingerprint: The fingerprint of the key to add.
-#     """
-#     cmd = GPG_KEYRING_CMD
-#     if debug:
-#         log.info('Would fetch key with fingerprint %s to %s', fingerprint, source.key_file)
-#         return
-#     key_data = self.ppa.
-    
-#     if not key_data:
-#         log.warning(
-#             ('Could not fetch key %s from keyserver. Check your '
-#             'internet connection. Re-run this command to try again'),
-#             fingerprint
-#         )
-#         return
-#     cmd += [f'--keyring={source.key_file}']
-#     with tempfile.TemporaryDirectory() as tempdir:
-#         cmd += ['--homedir', tempdir, '--import']
-#         try:
-#             subprocess.run(cmd, check=True, input=key_data)
-#         except subprocess.CalledProcessError:
-#             bus = dbus.SystemBus()
-#             privileged_object = bus.get_object('org.pop_os.repolib', '/Repo')
-#             cmd += [key_data.decode('UTF-8')]
-#             privileged_object.add_apt_signing_key(cmd)
-#             privileged_object.exit()

--- a/repolib/ppa.py
+++ b/repolib/ppa.py
@@ -112,6 +112,7 @@ class PPA:
             )
         return self._lap
 
+    # pylint: disable=raise-missing-from
     @property
     def lpteam(self):
         """ The Launchpad object for the PPA's owner."""

--- a/repolib/ppa.py
+++ b/repolib/ppa.py
@@ -112,19 +112,18 @@ class PPA:
             )
         return self._lap
 
-    # pylint: disable=raise-missing-from
     @property
     def lpteam(self):
         """ The Launchpad object for the PPA's owner."""
         if not self._lpteam:
             try:
                 self._lpteam = self.lap.people(self.teamname)
-            except NotFound:
+            except NotFound as err:
                 msg = f'User/Team "{self.teamname}" not found'
-                raise PPAError(msg)
-            except Unauthorized:
+                raise PPAError(msg) from err
+            except Unauthorized as err:
                 msg = f'Invalid user/team name "{self.teamname}"'
-                raise PPAError(msg)
+                raise PPAError(msg) from err
         return self._lpteam
 
     @property
@@ -133,12 +132,12 @@ class PPA:
         if not self._lpppa:
             try:
                 self._lpppa = self.lpteam.getPPAByName(name=self.ppaname)
-            except NotFound:
+            except NotFound as err:
                 msg = f'PPA "{self.teamname}/{self.ppaname}"" not found'
-                raise PPAError(msg)
-            except BadRequest:
+                raise PPAError(msg) from err
+            except BadRequest as err:
                 msg = f'Invalid PPA name "{self.ppaname}"'
-                raise PPAError(msg)
+                raise PPAError(msg) from err
         return self._lpppa
 
     @property

--- a/repolib/ppa_test.py
+++ b/repolib/ppa_test.py
@@ -26,8 +26,6 @@ This is a library for parsing deb lines into deb822-format data.
 
 import unittest
 
-from urllib.error import URLError
-
 from . import ppa
 from . import util
 

--- a/repolib/ppa_test.py
+++ b/repolib/ppa_test.py
@@ -58,24 +58,3 @@ class PPATestCase(unittest.TestCase):
 
     def test_options(self):
         self.assertFalse(self.source.options)
-
-    def test_internet_features(self):
-        try:
-            self.source.load_from_ppa()
-            self.assertEqual(self.source.name, 'Pop!_OS PPA')
-            self.assertNotEqual(self.source.ppa_info, {})
-        except util.RepoError as err:
-            # pylint: disable=no-else-raise, no-member
-            # This is a valid time to else raise since we're catching
-            # a different type of error.
-            if isinstance(err.args[-1], URLError):
-                if "Name or service not known" in str(err.args[-1].reason):
-                    raise unittest.SkipTest(
-                        'Can\'t test internet features without network.'
-                    )
-                elif "Connection refused" in str(err.args[-1].reason):
-                    raise unittest.SkipTest(
-                        'Couldn\'t fetch details from network.'
-                    )
-            else:
-                raise err

--- a/repolib/source.py
+++ b/repolib/source.py
@@ -92,6 +92,7 @@ class Source(deb822.Deb822):
         if ident:
             self.ident = ident
 
+        self.key_file = util.get_keys_dir() / f'{self.ident}.gpg'
         self.comment = '## Added/managed by repolib ##\n#\n'
 
     def load_from_file(self, filename=None, ident=None):
@@ -190,6 +191,7 @@ class Source(deb822.Deb822):
             # Use the ident as a fallback as it should be good enough
             name = self.ident
 
+        self.key_file = util.get_keys_dir() / f'{self.ident}.gpg'
         return name
 
     def init_values(self):

--- a/repolib/util.py
+++ b/repolib/util.py
@@ -23,7 +23,7 @@ along with RepoLib.  If not, see <https://www.gnu.org/licenses/>.
 from enum import Enum
 from pathlib import Path
 from urllib.parse import urlparse
-import urllib.request, urllib.error
+from urllib import request, error
 
 SOURCES_DIR = '/etc/apt/sources.list.d'
 KEYS_DIR = '/etc/apt/trusted.gpg.d'
@@ -105,18 +105,18 @@ def fetch_key(fingerprint, query_url=KEYSERVER_QUERY_URL):
     Arguments:
         :str fingerprint: The fingerprint of the key to fetch.
         :str query_url: the URL to use to fetch the query.
-    
+
     Returns
         :Bytes: The data containing the Key data.
     """
 
     full_url = query_url + fingerprint
     try:
-        request = urllib.request.urlopen(full_url)
-    except urllib.error.URLError:
-        request = None
-    
-    return request.read()
+        req = request.urlopen(full_url)
+    except error.URLError:
+        req = None
+
+    return req.read()
 
 def url_validator(url):
     """ Validate a url and tell if it's good or not.
@@ -178,16 +178,16 @@ def get_keys_dir(testing=False):
 
     Arguments:
         :bool testing: Whether we should be in testing mode or not.
-    
+
     Returns:
         pathlib.Path: The Keys dir.
     """
-    # pyline: disable=global-statement
+    # pylint: disable=global-statement
     # As with get_sources_dir(), we're setting a mode here.
     if testing:
         global KEYS_DIR
         KEYS_DIR = '/tmp/replib_testing/keys'
-    
+    # pylint: enable=global-statement
     keys_dir = Path(KEYS_DIR)
     keys_dir.mkdir(parents=True, exist_ok=True)
     return keys_dir


### PR DESCRIPTION
Adds in PPA signing key management to Repolib

Some Launchpad PPAs appear to be non-functional with the existing key management (which relied on `apt-key`). Additionally, `apt-key` has been officially deprecated and will not be supported in future versions. 

With this PR, signing keys are added to a new keyring in `/etc/apt/trusted.gpg.d` and are removed when a PPA repository is removed. Keys are fetched and manually imported using GPG rather than apt-key. This matches the way that SoftwareProperties handles signing keys.

A known example of a problematic PPA is the `ppa:boltgolt/howdy` repository, which would cause the failures indicated in #36 when added using Repolib, but which would be added successfully using `add-apt-repository`.

Required by pop-os/repoman#94
Fixes: #36 