### PR TITLE
fix(debian): improve preinst and prerm behavior

### DIFF
--- a/debian/postinst
+++ b/debian/postinst
@@ -8,9 +8,9 @@ if [[ -e /usr/bin/add-apt-repository ]]; then
         echo 'Something other than software-properties or repolib is providing add-apt-repository, not linking'
     elif [[ `readlink -f /usr/bin/add-apt-repository` = '/usr/lib/repolib/add-apt-repository' ]]; then
         echo 'add-apt-repository is already provided by repolib'
-    else
-        ln -s /usr/lib/repolib/add-apt-repository /usr/bin/add-apt-repository
     fi
+else
+    ln -s /usr/lib/repolib/add-apt-repository /usr/bin/add-apt-repository
 fi
 
 if [[ -e /usr/bin/apt-add-repository ]]; then
@@ -20,7 +20,7 @@ if [[ -e /usr/bin/apt-add-repository ]]; then
         echo 'Something other than software-properties or repolib is providing apt-add-repository, not linking'
     elif [[ `readlink -f /usr/bin/apt-add-repository` = '/usr/lib/repolib/add-apt-repository' ]]; then
         echo 'apt-add-repository is already provided by repolib'
-    else
-        ln -s /usr/lib/repolib/add-apt-repository /usr/bin/apt-add-repository
     fi
+else
+    ln -s /usr/lib/repolib/add-apt-repository /usr/bin/apt-add-repository
 fi

--- a/debian/postinst
+++ b/debian/postinst
@@ -1,7 +1,26 @@
 #!/bin/bash
 
 ## Provide a replacement for the add-apt-repository command 
-if [[ `dpkg -s software-properties-common | grep 'Status'` != *'installed'* ]]; then 
-    ln -s /usr/lib/repolib/add-apt-repository /usr/bin/add-apt-repository
-    ln -s /usr/lib/repolib/add-apt-repository /usr/bin/apt-add-repository
+if [[ -e /usr/bin/add-apt-repository ]]; then
+    if [[ `dpkg -s software-properties-common | grep 'Status'` = *'installed'* ]]; then
+        echo 'add-apt-repository is being provided by software-properties, not linking'
+    elif [[ `readlink -f /usr/bin/add-apt-repository` != '/usr/lib/repolib/add-apt-repository' ]]; then
+        echo 'Something other than software-properties or repolib is providing add-apt-repository, not linking'
+    elif [[ `readlink -f /usr/bin/add-apt-repository` = '/usr/lib/repolib/add-apt-repository' ]]; then
+        echo 'add-apt-repository is already provided by repolib'
+    else
+        ln -s /usr/lib/repolib/add-apt-repository /usr/bin/add-apt-repository
+    fi
+fi
+
+if [[ -e /usr/bin/apt-add-repository ]]; then
+    if [[ `dpkg -s software-properties-common | grep 'Status'` = *'installed'* ]]; then
+        echo 'apt-add-repository is being provided by software-properties, not linking'
+    elif [[ `readlink -f /usr/bin/apt-add-repository` != '/usr/lib/repolib/add-apt-repository' ]]; then
+        echo 'Something other than software-properties or repolib is providing apt-add-repository, not linking'
+    elif [[ `readlink -f /usr/bin/apt-add-repository` = '/usr/lib/repolib/add-apt-repository' ]]; then
+        echo 'apt-add-repository is already provided by repolib'
+    else
+        ln -s /usr/lib/repolib/add-apt-repository /usr/bin/apt-add-repository
+    fi
 fi

--- a/debian/prerm
+++ b/debian/prerm
@@ -1,0 +1,21 @@
+#!/bin/bash
+
+if [[ -e /usr/bin/add-apt-repository ]]; then
+    if [[ `dpkg -s software-properties-common | grep 'Status'` = *'installed'* ]]; then
+        echo 'add-apt-repository is being provided by software-properties, not unlinking'
+    elif [[ `readlink -f /usr/bin/add-apt-repository` = '/usr/lib/repolib/add-apt-repository' ]]; then
+        unlink /usr/bin/add-apt-repository
+    else
+        echo 'Something other than software-properties or repolib is providing add-apt-repository, not unlinking'
+    fi
+fi
+
+if [[ -e /usr/bin/apt-add-repository ]]; then
+    if [[ `dpkg -s software-properties-common | grep 'Status'` = *'installed'* ]]; then
+        echo 'apt-add-repository is being provided by software-properties, not unlinking'
+    elif [[ `readlink -f /usr/bin/apt-add-repository` = '/usr/lib/repolib/add-apt-repository' ]]; then
+        unlink /usr/bin/apt-add-repository
+    else
+        echo 'Something other than software-properties or repolib is providing apt-add-repository, not unlinking'
+    fi
+fi


### PR DESCRIPTION
Rewrite the preinst script (and add a prerm script) that will improve fault tolerance for certain situations that may be encountered depending on packages and user-setup on systems. This ensures that we only create a symlink for `add-apt-repository` if it isn't already present, that we don't attempt to create a duplicate (and fail) if we're already managing it, and we don't remove them unless we are the ones who set it up.

This also splits handling of both `add-apt-repository` and `apt-add-repository` into separate sections so that we can handle them individually.

Fixes #42 