### PR TITLE
fix(deb-triggers): watch add-apt-repository for changes

### DIFF
--- a/debian/triggers
+++ b/debian/triggers
@@ -1,0 +1,1 @@
+interest /usr/bin/add-apt-repository


### PR DESCRIPTION
Adds a Debian trigger to the packaging information that will monitor the `add-apt-repository` command and re-run our automatic linker if any other package modifies it. This means that if a user removes `software-properties-common` from their system, repolib will step in to provide the `add-apt-repository` command automatically. Since we're only providing links, if the user reinstalls `software-properties-common` (or another package pulls it in as a dependency), it will revert back to letting it provide that command. 

I think this is a relatively elegant solution to providing this behavior, as it's fully automatic and allows the utility to be provided by whichever package is likely depending on that command, and because it uses established debian packaging guidelines which correctly resolve to the correct state regardless of what actions the user takes. It also prevents us from needing to apply a blanket `Conflicts:`rule, which would prevent the installation of `software-properties-common` (as well as any packages which depend on it); the Repolib library does not conflict with functionality provided by the SoftwareProperties library, and it's utilities are mostly separate as well; `apt-manage` is not provided by `software-properties-common` and Repolib only provides an `add-apt-repository` alias as a convenience for users more accustomed to using that command. It's appropriate for us to provide it when it's absent, as well as being appropriate for us to gracefully bow out where it's present.

One potential alternative to this method would be configuring a Debian Alternative to allow the user to configure which package is providing that command. My belief is that the trigger-based solution is better than this because Alternatives are traditionally used to allow the user to select conceptually similar but functionally separate programs (i.e. picking a terminal emulator as the system default). Because our implementation of `add-apt-repository` is intended to be functionally identical to that provided by `software-properties-common` (albeit using the Repolib library instead of SoftwareProperties), this wouldn't be a benefit to users and it would be better to allow `software-properties-common` to always provide that command if the package is present because it would ensure odd corner cases caused by tools depending on that utility would be correctly handled by dependent software.

Closes #44 