### PR TITLE
Fix if a source does not have a name set

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,9 @@
+repolib (2.0.1) jammy; urgency=medium
+
+  * Fix for sources missing names (pop-os/repolib/#49)
+
+ -- Ian Santopietro <ian@system76.com>  Wed, 05 Oct 2022 14:25:59 -0600
+
 repolib (2.0.0) jammy; urgency=medium
 
   * Newly rewritten architecture

--- a/repolib/command/list.py
+++ b/repolib/command/list.py
@@ -178,7 +178,7 @@ class List(Command):
             if self.verbose or self.debug:
                 print('\nDetails about failing files:')
                 for err in util.errors:
-                    print(f'{err}: {util.errors[err]}')
+                    print(f'{err}: {util.errors[err].args[0]}')
                     
         return True
     

--- a/repolib/file.py
+++ b/repolib/file.py
@@ -410,6 +410,13 @@ class SourceFile:
             item += 1
             self.contents.append('')
         
+        for source in self.sources:
+            if not source.has_required_parts:
+                raise SourceFileError(
+                    f'The file {self.path.name} is malformed and contains '
+                    'errors. Maybe it has some extra new-lines?'
+                )
+        
         self.log.debug('File %s loaded', self.path)
 
     def save(self) -> None:

--- a/repolib/parsedeb.py
+++ b/repolib/parsedeb.py
@@ -20,7 +20,11 @@ You should have received a copy of the GNU Lesser General Public License
 along with RepoLib.  If not, see <https://www.gnu.org/licenses/>.
 """
 
+import logging
+
 from . import util
+
+log = logging.getLogger(__name__)
 
 class DebParseError(util.RepoError):
     """ Exceptions related to parsing deb lines."""
@@ -126,7 +130,9 @@ def parse_name_ident(tail:str) -> tuple:
 
     # Used for sanity checking later
     has_name = 'X-Repolib-Name' in tail
+    log.debug('Line name found: %s', has_name)
     has_ident = 'X-Repolib-ID' in tail
+    log.debug('Line ident found: %s', has_ident)
 
     parts: list = tail.split()
     name_found = False
@@ -135,6 +141,7 @@ def parse_name_ident(tail:str) -> tuple:
     ident:str = ''
     comment:str = ''
     for item in parts:
+        log.debug("Checking line item: %s", item)
         item_is_name = item.strip('#').strip().startswith('X-Repolib-Name')
         item_is_ident = item.strip('#').strip().startswith('X-Repolib-ID')
         
@@ -168,6 +175,10 @@ def parse_name_ident(tail:str) -> tuple:
     name = name.strip()
     ident = ident.strip()
     comment = comment.strip()
+
+    if not name:
+        if ident: 
+            name = ident
 
     # Final sanity checking
     if has_name and not name:

--- a/repolib/source.py
+++ b/repolib/source.py
@@ -226,7 +226,12 @@ class Source(deb822.Deb822):
             A name based on the ident
         """
         name:str = self.ident
-        if not self['X-Repolib-Name']:
+        try:
+            name = self['X-Repolib-Name']
+        except KeyError:
+            name = self.ident
+
+        if name:
             self['X-Repolib-Name'] = name
         
         return name

--- a/repolib/source.py
+++ b/repolib/source.py
@@ -229,12 +229,13 @@ class Source(deb822.Deb822):
         try:
             name = self['X-Repolib-Name']
         except KeyError:
-            name = self.ident
+            self['X-Repolib-Name'] = self.ident
+            return self['X-Repolib-Name']
 
-        if name:
-            self['X-Repolib-Name'] = name
+        if not name:
+            self['X-Repolib-Name'] = self.ident
         
-        return name
+        return self['X-Repolib-Name']
 
     def load_key(self, ignore_errors:bool = True) -> None:
         """Finds and loads the signing key from the system


### PR DESCRIPTION
I believe the issue described in #49 is caused by some sources being added which don't have an explicit name set. When version 2.0.0 of Repoman checks over these sources, there is not an `X-Repolib-Name` key set, causing the `KeyError` described. This fixes this by wrapping that key in a `try: except:` statement and setting a fallback value.

Fixes #49 
Fixes pop-os/repoman#103