### PR TITLE
Bugfixes

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,13 @@
+repolib (2.1.0) jammy; urgency=medium
+
+  * Repolib will now search for mis-typed repos when removing sources
+    Mistyped repos (if found on the system) are offered as a correction
+  * Fixed a bug where popdev: shortcuts containing slashes could be added
+  * Prints a suggestion for common "popdev/" typo
+  * Fixed a typo in the remove subcommand
+
+ -- Ian Santopietro <ian@system76.com>  Tue, 11 Oct 2022 11:35:07 -0600
+
 repolib (2.0.1) jammy; urgency=medium
 
   * Fix for sources missing names (pop-os/repolib/#49)

--- a/repolib/__init__.py
+++ b/repolib/__init__.py
@@ -124,6 +124,7 @@ SourceFormat = util.SourceFormat
 SourceType = util.SourceType
 AptSourceEnabled = util.AptSourceEnabled
 
+scrub_filename = util.scrub_filename
 url_validator = util.url_validator
 prettyprint_enable = util.prettyprint_enable
 validate_debline = util.validate_debline

--- a/repolib/command/add.py
+++ b/repolib/command/add.py
@@ -124,7 +124,8 @@ class Add(Command):
             ident = args.identifier
 
         self.name = ' '.join(name)
-        self.ident = '-'.join(ident).translate(util.CLEAN_CHARS)
+        pre_ident:str = '-'.join(ident)
+        self.ident = util.scrub_filename(pre_ident)
         self.skip_keys = args.skip_keys
         self.format = args.format.lower()
     

--- a/repolib/command/add.py
+++ b/repolib/command/add.py
@@ -156,8 +156,14 @@ class Add(Command):
                         'The shortcut "%s" is malformed',
                         self.deb_line
                     )
-                    if self.deb_line.startswith('popdev/'):
-                        print(f'Did you mean "{self.deb_line.replace("/", ":")}"?')
+
+                    # Try and get a suggested correction for common errors
+                    try:
+                        if self.deb_line[len(prefix)] != ':':
+                            broken_delim = self.deb_line[len(prefix)]
+                            print(f'Did you mean "{self.deb_line.replace(broken_delim, ":")}"?')
+                    except IndexError:
+                        pass
                     return False
                 break
         

--- a/repolib/command/add.py
+++ b/repolib/command/add.py
@@ -160,8 +160,12 @@ class Add(Command):
                     # Try and get a suggested correction for common errors
                     try:
                         if self.deb_line[len(prefix)] != ':':
-                            broken_delim = self.deb_line[len(prefix)]
-                            print(f'Did you mean "{self.deb_line.replace(broken_delim, ":")}"?')
+                            fixed_debline: str = self.deb_line.replace(
+                                self.deb_line[len(prefix)], 
+                                ":",
+                                1
+                            )
+                            print(f'Did you mean "{fixed_debline}"?')
                     except IndexError:
                         pass
                     return False

--- a/repolib/command/add.py
+++ b/repolib/command/add.py
@@ -150,6 +150,14 @@ class Add(Command):
             if self.deb_line.startswith(prefix):
                 self.log.debug('Line is prefix:  %s', prefix)
                 new_source = shortcut_prefixes[prefix]()
+                if not new_source.validator(self.deb_line):
+                    self.log.error(
+                        'The shortcut "%s" is malformed',
+                        self.deb_line
+                    )
+                    if self.deb_line.startswith('popdev/'):
+                        print(f'Did you mean "{self.deb_line.replace("/", ":")}"?')
+                    return False
                 break
         
         new_source.load_from_data([self.deb_line])

--- a/repolib/command/remove.py
+++ b/repolib/command/remove.py
@@ -83,7 +83,7 @@ class Remove(Command):
             self.key = self.source.key
             self.file = self.source.file
         
-        print(f'This will remzove the source {self.source_name}')
+        print(f'This will remove the source {self.source_name}')
         print(self.source.ui)
         response:str = 'n'
         if self.assume_yes:

--- a/repolib/command/remove.py
+++ b/repolib/command/remove.py
@@ -77,11 +77,24 @@ class Remove(Command):
                 'Source %s was not found. Double-check the spelling',
                 self.source_name
             )
-            return False
-        else:
-            self.source = util.sources[self.source_name]
-            self.key = self.source.key
-            self.file = self.source.file
+            source_list:list = []
+            for source in util.sources:
+                source_list.append(source)
+            suggested_source:str = self.source_name.replace(':', '-')
+            suggested_source = suggested_source.translate(util.CLEAN_CHARS)
+            if not suggested_source in source_list:
+                return False
+
+            response:str = input(f'Did you mean "{suggested_source}"? (Y/n) ')
+            if not response:
+                response = 'y'
+            if response not in util.true_values:
+                return False
+            self.source_name = suggested_source
+
+        self.source = util.sources[self.source_name]
+        self.key = self.source.key
+        self.file = self.source.file
         
         print(f'This will remzove the source {self.source_name}')
         print(self.source.ui)

--- a/repolib/shortcuts/popdev.py
+++ b/repolib/shortcuts/popdev.py
@@ -53,7 +53,7 @@ class PopdevSource(Source):
     default_format = BASE_FORMAT
 
     @staticmethod
-    def validator(shortcut:str) -> None:
+    def validator(shortcut:str) -> bool:
         """Determine whether a PPA shortcut is valid.
         
         Arguments:
@@ -63,6 +63,13 @@ class PopdevSource(Source):
             `True` if the PPA is valid, otherwise False
         """
         if '/' in shortcut:
+            return False
+
+        shortcut_split = shortcut.split(':')
+        try:
+            if not shortcut_split[1]:
+                return False
+        except IndexError:
             return False
 
         if shortcut.startswith(f'{prefix}:'):

--- a/repolib/shortcuts/popdev.py
+++ b/repolib/shortcuts/popdev.py
@@ -62,11 +62,14 @@ class PopdevSource(Source):
         Returns: bool
             `True` if the PPA is valid, otherwise False
         """
+        if '/' in shortcut:
+            return False
 
         if shortcut.startswith(prefix):
-            shortlist = shortcut.split('/')
+            shortlist = shortcut.split(':')
             if len(shortlist) > 0:
                 return True
+                
         return False
 
     def __init__(self, *args, line=None, fetch_data=True, **kwargs):

--- a/repolib/shortcuts/popdev.py
+++ b/repolib/shortcuts/popdev.py
@@ -65,7 +65,7 @@ class PopdevSource(Source):
         if '/' in shortcut:
             return False
 
-        if shortcut.startswith(prefix):
+        if shortcut.startswith(f'{prefix}:'):
             shortlist = shortcut.split(':')
             if len(shortlist) > 0:
                 return True

--- a/repolib/shortcuts/popdev.py
+++ b/repolib/shortcuts/popdev.py
@@ -76,9 +76,10 @@ class PopdevSource(Source):
         super().__init__(args, kwargs)
         self.log = logging.getLogger(__name__)
         self.line = line
-        self.twin_source = True
+        self.twin_source:bool = True
         self.prefs_path = None
-        self.branch_name = ''
+        self.branch_name:str = ''
+        self.branch_url:str = ''
         if line:
             self.load_from_shortcut(self.line)
     
@@ -86,7 +87,7 @@ class PopdevSource(Source):
         super().tasks_save(*args, **kwargs)
         self.log.info('Saving prefs file for %s', self.ident)
         prefs_contents = 'Package: *\n'
-        prefs_contents += f'Pin: release o=pop-os-staging-{self.branch_name}\n'
+        prefs_contents += f'Pin: release o=pop-os-staging-{self.branch_url}\n'
         prefs_contents += 'Pin-Priority: 1002\n'
 
         self.log.debug('%s prefs for pin priority:\n%s', self.ident, prefs_contents)
@@ -129,7 +130,8 @@ class PopdevSource(Source):
         self.log.debug('Loading shortcut %s', self.line)
         
         self.info_parts = shortcut.split(delineator)
-        self.branch_name = util.scrub_filename(':'.join(self.info_parts[1:]))
+        self.branch_url = ':'.join(self.info_parts[1:])
+        self.branch_name = util.scrub_filename(name=self.branch_url)
         self.log.debug('Popdev branch name: %s', self.branch_name)
 
         self.ident = f'{prefix}-{self.branch_name}'
@@ -144,7 +146,7 @@ class PopdevSource(Source):
         self.file.add_source(self)
         
         self.name = f'Pop Development Branch {self.branch_name}'
-        self.uris = [f'{BASE_URL}/{self.branch_name}']
+        self.uris = [f'{BASE_URL}/{self.branch_url}']
         self.suites = [util.DISTRO_CODENAME]
         self.components = [BASE_COMPS]
 

--- a/repolib/shortcuts/popdev.py
+++ b/repolib/shortcuts/popdev.py
@@ -129,7 +129,7 @@ class PopdevSource(Source):
         self.log.debug('Loading shortcut %s', self.line)
         
         self.info_parts = shortcut.split(delineator)
-        self.branch_name = ':'.join(self.info_parts[1:])
+        self.branch_name = util.scrub_filename(':'.join(self.info_parts[1:]))
         self.log.debug('Popdev branch name: %s', self.branch_name)
 
         self.ident = f'{prefix}-{self.branch_name}'

--- a/repolib/shortcuts/ppa.py
+++ b/repolib/shortcuts/ppa.py
@@ -68,7 +68,7 @@ class PPASource(Source):
             `True` if the PPA is valid, otherwise False
         """
 
-        if shortcut.startswith(prefix):
+        if shortcut.startswith(f'{prefix}:'):
             shortlist = shortcut.split('/')
             if len(shortlist) > 1:
                 return True

--- a/repolib/shortcuts/ppa.py
+++ b/repolib/shortcuts/ppa.py
@@ -58,7 +58,7 @@ class PPASource(Source):
     default_format = BASE_FORMAT
 
     @staticmethod
-    def validator(shortcut:str) -> None:
+    def validator(shortcut:str) -> bool:
         """Determine whether a PPA shortcut is valid.
         
         Arguments:

--- a/repolib/source.py
+++ b/repolib/source.py
@@ -203,14 +203,13 @@ class Source(deb822.Deb822):
         Returns: str
             A sane default-id
         """
-        ident = ''
+        ident:str = ''
         if len(self.uris) > 0:
-            uri = self.uris[0].replace('/', ' ')
-            uri_list = uri.split()
-            ident = '{}{}'.format(
-                prefix,
-                '-'.join(uri_list[1:]).translate(util.CLEAN_CHARS)
-            )
+            uri:str = self.uris[0].replace('/', ' ')
+            uri_list:list = uri.split()
+            uri_str:str = '-'.join(uri_list[1:])
+            branch_name:str = util.scrub_filename(uri_str)
+            ident = f'{prefix}{branch_name}'
         ident += f'-{self.types[0].ident()}'
         try:
             if not self['X-Repolib-ID']:
@@ -331,7 +330,7 @@ class Source(deb822.Deb822):
 
     @ident.setter
     def ident(self, ident: str) -> None:
-        ident = ident.translate(util.CLEAN_CHARS)
+        ident = util.scrub_filename(ident)
         self['X-Repolib-ID'] = ident
 
 

--- a/repolib/util.py
+++ b/repolib/util.py
@@ -216,6 +216,18 @@ files:dict = {}
 keys:dict = {}
 errors:dict = {}
 
+
+def scrub_filename(name: str = '') -> str:
+    """ Clean up a string intended for a filename.
+    
+    Arguments:
+        name (str): The prospective name to scrub.
+    
+    Returns: str
+        The cleaned-up name.
+    """
+    return name.translate(CLEAN_CHARS)
+
 def set_testing(testing:bool=True) -> None:
     """Sets Repolib in testing mode where changes will not be saved.
     


### PR DESCRIPTION
Fixes #51 
When adding a `popdev:` shortcut, slashes are an invalid character for staging branches, so they should never be allowed in `popdev:` shortcuts. Additionally, if the user enters `popdev/` instead of `popdev:`, print the suggested correction to console with the error. Also adds a suggestion for missing branches where the user entered the branch using the `add` format `popdev:branchname` instead of the `remove` format `popdev-branchname` if such a branch exists, and offers to use that instead without modifying the command entered (Feedback from QA).

Fixes #52 
When adding a `popdev:` shortcut with a branch name containing dots, the preferences file written contains those dots, leading Apt to ignore the preferences file (and subsequently not update those packages). This ensures that the preferences files written by Repolib do not contain dots, while ensuring that the dots are preserved in the `.sources` entry as well as the preferences file (as they are required for the URI).

Fixes #53
Corrects a typo in the `remove` subcommand as demonstrated in #53 