### PR TITLE
Improve error handling for apt-manage commands

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,9 @@
+repolib (2.1.1) jammy; urgency=medium
+
+  * Improved error CLI error handling
+
+ -- Ian Santopietro <ian@system76.com>  Thu, 20 Oct 2022 10:32:43 -0600
+
 repolib (2.1.0) jammy; urgency=medium
 
   * Repolib will now search for mis-typed repos when removing sources

--- a/repolib/__version__.py
+++ b/repolib/__version__.py
@@ -19,4 +19,4 @@ GNU Lesser General Public License for more details.
 You should have received a copy of the GNU Lesser General Public License
 along with RepoLib.  If not, see <https://www.gnu.org/licenses/>.
 """
-__version__ = "2.0.0"
+__version__ = "2.1.1"

--- a/repolib/command/add.py
+++ b/repolib/command/add.py
@@ -20,6 +20,9 @@ You should have received a copy of the GNU Lesser General Public License
 along with RepoLib.  If not, see <https://www.gnu.org/licenses/>.
 """
 
+from httplib2.error import ServerNotFoundError
+from urllib.error import URLError
+
 from .. import util
 from ..source import Source, SourceError
 from ..file import SourceFile, SourceFileError
@@ -172,7 +175,17 @@ class Add(Command):
                         pass
                     return False
                 
-                new_source.load_from_data([self.deb_line])
+                try:
+                    new_source.load_from_data([self.deb_line])
+                except (URLError, ServerNotFoundError) as err:
+                    self.log.error(
+                        'System is offline. A connection is required to add '
+                        'PPA and Popdev sources.'
+                    )
+                    return False
+                except Exception as err:
+                    self.log.error('An error ocurred: %s', err)
+                    return False
                 break
         
         

--- a/repolib/command/add.py
+++ b/repolib/command/add.py
@@ -178,12 +178,26 @@ class Add(Command):
                 try:
                     new_source.load_from_data([self.deb_line])
                 except (URLError, ServerNotFoundError) as err:
+                    import traceback
+                    self.log.debug(
+                        'Exception info: %s \n %s \n %s',
+                        type(err),
+                        ''.join(traceback.format_exception(err)),
+                        err.args
+                    )
                     self.log.error(
                         'System is offline. A connection is required to add '
                         'PPA and Popdev sources.'
                     )
                     return False
                 except Exception as err:
+                    import traceback
+                    self.log.debug(
+                        'Exception info: %s \n %s \n %s',
+                        type(err),
+                        err.__traceback__,
+                        err
+                    )
                     self.log.error('An error ocurred: %s', err)
                     return False
                 break


### PR DESCRIPTION
This adds error handling to the method call which loads data from a given repository. It's good to catch these errors to prevent a traceback from being printed to the console, while also informing the user that there was an issue with the operation (and if possible providing some context as to steps to take to correct them). 

The most common issues arise from the system being offline when running the commands, which are required for adding PPA sources as well as the first Popdev source added to a system (or after all of them are removed) in order to download the signing key. However, other unexpected errors are also handled the same way.

Exception/Traceback information are caught and logged with a loglevel of DEBUG, so running the command with the `-bb` flag still prints the exception/traceback, which could be useful for support/debugging.