### PR TITLE
Adds API and CLI for retrieving/printing signing key information

### DIFF
--- a/data/zsh-completion/_apt-manage
+++ b/data/zsh-completion/_apt-manage
@@ -44,6 +44,7 @@ case "$state" in
       '--ascii'
       '--fingerprint'
       '--keyserver'
+      '--info'
       '--remove'
       # List subcommand
       '--legacy'

--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,10 @@
+repolib (2.2.0) jammy; urgency=medium
+
+  * Adds API for getting signing key details
+  * Adds CLI option to print signing key information
+
+ -- Ian Santopietro <ian@system76.com>  Wed, 26 Oct 2022 15:56:23 -0600
+
 repolib (2.1.1) jammy; urgency=medium
 
   * Improved error CLI error handling

--- a/repolib/__version__.py
+++ b/repolib/__version__.py
@@ -19,4 +19,4 @@ GNU Lesser General Public License for more details.
 You should have received a copy of the GNU Lesser General Public License
 along with RepoLib.  If not, see <https://www.gnu.org/licenses/>.
 """
-__version__ = "2.1.1"
+__version__ = "2.2.0"

--- a/repolib/command/key.py
+++ b/repolib/command/key.py
@@ -166,9 +166,18 @@ class Key(Command):
             )
             return False
         
-        if not True in self.actions:
-            self.actions['info'] = True
         self.log.debug('Actions to take:\n%s', self.actions)
+        # Run info, unless a different action is specified
+        self.actions['info'] = True
+        for key in self.actions:
+            if key == 'info':
+                self.log.debug('Skipping info key')
+                continue
+            if self.actions[key]:
+                self.log.info('Got an action, skipping info')
+                self.actions['info'] = False
+                break
+         
         self.log.debug('Source before:\n%s', self.source)
 
         rets = []
@@ -182,9 +191,13 @@ class Key(Command):
         self.log.debug('Results: %s', rets)
         self.log.debug('Source after: \n%s', self.source)
 
+        if self.actions['info']:
+            self.log.info('Running Info, skipping saving %s', self.source.ident)
+            return True
+
         if True in rets:
-            if not self.actions['info']:
-                self.source.file.save()
+            self.log.info('Saving source %s', self.source.ident)
+            self.source.file.save()
             return True
         else:
             self.log.warning('No valid changes specified, no actions taken.')
@@ -301,7 +314,7 @@ class Key(Command):
                 'The source %s does not have a key configured.', 
                 self.repo
             )
-            return False
+            return True
 
         else:
             key:dict = self.source.get_key_info()

--- a/repolib/source.py
+++ b/repolib/source.py
@@ -139,6 +139,31 @@ class Source(deb822.Deb822):
         """
         return self.name
     
+    def get_key_info(self, halt_errors: bool = False) -> dict:
+        """ Get a dictionary containing information for the signing key for
+        this source.
+
+        Arguments:
+            halt_errors (bool): if there are errors or other unexpected data, 
+                raise a SourceError exception. Otherwise, simply log a warning.
+        
+        Returns: dict
+            The dictionary from gnupg with key info.
+        """
+        if self.key:
+            keys:list = self.key.gpg.list_keys()
+            if len(keys) > 1:
+                error_msg = (
+                        f'The keyring for {self.ident} contains {len(keys)} keys'
+                        '. Check the keyring object for details about the keys.'
+                    )
+                if halt_errors:
+                    raise SourceError(error_msg)
+                self.log.warning(error_msg)
+            return keys[0]
+        
+        return {}
+    
     def reset_values(self) -> None:
         """Reset the default values for all attributes"""
         self.log.info('Resetting source info')


### PR DESCRIPTION
Adds a simple API for collecting details about signing keys from sources. Also adds a CLI option to utilize this output and print information about signing keys to console.

Testing:
* Ensure that there is a `popdev` staging branch added (as these will have signing keys). (`sudo apt-manage add popdev:master` if not)
* Ensure that running `apt-manage key popdev-master --info` returns the correct signing details about the source.
* Ensure that running `apt-manage key popdev-master` correctly defaults to the `--info` option and prints signing details
* Ensure that running `apt-manage key` with a repo which does not have a key configured (e.g. `apt-manage key pop-os-apps`) prints an error message and exits without an exception or traceback.