### PR TITLE
Do not crash if dbus conncetion fails to disconnect

### DIFF
--- a/src/repolib/command/add.py
+++ b/src/repolib/command/add.py
@@ -264,5 +264,8 @@ class Add(Command):
                 exit(0)
         
         new_file.save()
-        util.dbus_quit()
+        try:
+            util.dbus_quit()
+        except:
+            self.log.warning('Failed to disconnect from dbus session.')
         return True


### PR DESCRIPTION
For https://github.com/pop-os/iso/pull/318
Required so that apt-manage doesn't crash when in a chroot-ed install environment