### PR TITLE
More robust installation instrucitons for Ubuntu and Debian

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -81,50 +81,16 @@ If your operating system packages repolib, you can install it by running::
 From Pre-Compiled .deb Package
 ------------------------------
 
-If your distro does not yet supply the package, you can install the
-`latest release`__ using the script below
-(replace ``PKG_VER='2.0.0'`` with the version you wish to install):
+When using any other Debian based distro, it's possible to install the
+`latest release`__ using the `quick_install.sh`__ script:
 
-.. code:: bash
+.. code:: shell
 
-    #! /usr/bin/env bash
-    
-    # Initialize some useful variables
-    PKG_VER='2.0.0'
-    PKG="python3-repolib_${PKG_VER}_all.deb"
-    URL="https://github.com/pop-os/repolib/releases/download/${PKG_VER}/$PKG"
-    PREREQ_PKG=(curl python3-gnupg python3-debian ca-certificates)
-    # Grab VERSION_ID and ID from /etc/os-release
-    . <(grep -E '^(VERSION_)?ID=' /etc/os-release)
-    
-    # Make sure we're using the right mix.
-    # Debian requires some missing packages.
-    [[ "$ID" == 'debian' ]] \
-    && PREREQ_PKG+=( debhelper dh-python python3-all \
-        python3-setuptools python3-gnupg python3-debian zstd )
-    
-    apt-get install --yes --no-install-recommends "${PREREQ_PKG[@]}"
-    
-    curl -Lo "/tmp/$PKG" "$URL"
-    
-    # If Running on Debian, zstd compression isn't supported by pkg.
-    # The code below repackages the deb packages using xz instead.
-    if [[ "$ID" == 'debian' ]]; then
-        echo "We're on debian, so repackaging without zstd compression..."
-        rm -r /tmp/repolib.tmp 2>/dev/null || true
-        mkdir -p /tmp/repolib.tmp && pushd /tmp/repolib.tmp/ >/dev/null \
-        && mv "/tmp/${PKG}" "${PKG}.tmp" \
-        && ar x "${PKG}.tmp" \
-        && zstd -d < control.tar.zst | xz > control.tar.xz \
-        && zstd -d < data.tar.zst | xz > data.tar.xz \
-        && ar -m -c -a sdsd "/tmp/${PKG}" debian-binary control.tar.xz data.tar.xz \
-        && popd >/dev/null
-    fi
-    
-    # Install the package
-    apt-get install --yes "/tmp/$PKG"
+    sudo apt update && sudo apt install --yes --no-install-recommends curl
+    sudo bash <(curl -s https://raw.githubusercontent.com/pop-os/repolib/HEAD/quick-install.sh)
 
 __ https://github.com/pop-os/repolib/releases/
+__ https://github.com/pop-os/repolib/blob/HEAD/quick-install.sh
 
 Uninstall
 ^^^^^^^^^

--- a/README.rst
+++ b/README.rst
@@ -75,9 +75,46 @@ From System Package Manager
 ---------------------------
 
 If your operating system packages repolib, you can install it by running::
-    
+
     sudo apt install python3-repolib
 
+If your distro does not yet supply the package, you can install the
+[latest release](https://github.com/pop-os/repolib/releases/) using the
+steps below (At the time of writing this, the version is 2.0.0):
+
+    # Initialize some useful variables
+    PKG=python3-repolib_2.0.0_all.deb
+    URL="https://github.com/pop-os/repolib/releases/download/2.0.0/$PKG"
+
+    PREREQ_PKG=(curl python3-gnupg python3-debian ca-certificates)
+    . <(grep -E '^(VERSION_)?ID=' /etc/os-release)
+
+    # Make sure we're using the right mix, debian requires some missing
+    # packages.
+    [[ "$ID" == 'debian' ]] \
+    && PREREQ_PKG+=( debhelper dh-python python3-all \
+        python3-setuptools python3-gnupg python3-debian zstd )
+
+    apt-get install --yes --no-install-recommends "${PREREQ_PKG[@]}"
+
+    curl -Lo "/tmp/$PKG" "$URL"
+
+    # If we're on debian, zstd compression isn't supported by pkg.
+    # So we repackage.
+    if [[ "$ID" == 'debian' ]]; then
+        echo "We're on debian, so repackaging without zstd compression..."
+        rm -r /tmp/repolib.tmp 2>/dev/null || true
+        mkdir -p /tmp/repolib.tmp && pushd /tmp/repolib.tmp/ >/dev/null \
+        && mv "/tmp/${PKG}" "${PKG}.tmp" \
+        && ar x "${PKG}.tmp" \
+        && zstd -d < control.tar.zst | xz > control.tar.xz \
+        && zstd -d < data.tar.zst | xz > data.tar.xz \
+        && ar -m -c -a sdsd "/tmp/${PKG}" debian-binary control.tar.xz data.tar.xz \
+        && popd >/dev/null
+    fi
+
+    # Install the package
+    apt-get install --yes "/tmp/$PKG"
 
 Uninstall
 ^^^^^^^^^

--- a/README.rst
+++ b/README.rst
@@ -82,16 +82,17 @@ From Pre-Compiled .deb Package
 ------------------------------
 
 If your distro does not yet supply the package, you can install the
-`latest release`__ using the script below (At the time of writing this,
-the version is 2.0.0):
+`latest release`__ using the script below
+(replace ``PKG_VER='2.0.0'`` with the version you wish to install):
 
 .. code:: bash
 
     #! /usr/bin/env bash
     
     # Initialize some useful variables
-    PKG=python3-repolib_2.0.0_all.deb
-    URL="https://github.com/pop-os/repolib/releases/download/2.0.0/$PKG"
+    PKG_VER='2.0.0'
+    PKG="python3-repolib_${PKG_VER}_all.deb"
+    URL="https://github.com/pop-os/repolib/releases/download/${PKG_VER}/$PKG"
     PREREQ_PKG=(curl python3-gnupg python3-debian ca-certificates)
     # Grab VERSION_ID and ID from /etc/os-release
     . <(grep -E '^(VERSION_)?ID=' /etc/os-release)

--- a/README.rst
+++ b/README.rst
@@ -82,10 +82,8 @@ From Pre-Compiled .deb Package
 ------------------------------
 
 If your distro does not yet supply the package, you can download and
-install the `.deb` package from the `latest release`__, which you can
-install with `apt install <deb package file>`.  
-A script to automatically download and install, including installing
-prerequisites, can be found in `quick_install.sh`__.
+install the .deb package from the `latest release`__.  
+A script to do this automatically can be found in `quick_install.sh`__.
  
 __ https://github.com/pop-os/repolib/releases/
 __ https://github.com/pop-os/repolib/blob/HEAD/quick-install.sh

--- a/README.rst
+++ b/README.rst
@@ -83,7 +83,7 @@ From Pre-Compiled .deb Package
 
 If your distro does not yet supply the package, you can download and
 install the .deb package from the `latest release`__.  
-A script to do this automatically can be found in `quick_install.sh`__ script.
+A script to do this automatically can be found in `quick_install.sh`__.
  
 __ https://github.com/pop-os/repolib/releases/
 __ https://github.com/pop-os/repolib/blob/HEAD/quick-install.sh

--- a/README.rst
+++ b/README.rst
@@ -71,36 +71,43 @@ Allows changing configuration details of a given repository
 Installation
 ============
 
-From System Package Manager
----------------------------
+From System Repository 
+----------------------
 
 If your operating system packages repolib, you can install it by running::
 
     sudo apt install python3-repolib
 
-If your distro does not yet supply the package, you can install the
-[latest release](https://github.com/pop-os/repolib/releases/) using the
-steps below (At the time of writing this, the version is 2.0.0):
+From Pre-Compiled .deb Package
+------------------------------
 
+If your distro does not yet supply the package, you can install the
+`latest release`__ using the script below (At the time of writing this,
+the version is 2.0.0):
+
+.. code:: bash
+
+    #! /usr/bin/env bash
+    
     # Initialize some useful variables
     PKG=python3-repolib_2.0.0_all.deb
     URL="https://github.com/pop-os/repolib/releases/download/2.0.0/$PKG"
-
     PREREQ_PKG=(curl python3-gnupg python3-debian ca-certificates)
+    # Grab VERSION_ID and ID from /etc/os-release
     . <(grep -E '^(VERSION_)?ID=' /etc/os-release)
-
-    # Make sure we're using the right mix, debian requires some missing
-    # packages.
+    
+    # Make sure we're using the right mix.
+    # Debian requires some missing packages.
     [[ "$ID" == 'debian' ]] \
     && PREREQ_PKG+=( debhelper dh-python python3-all \
         python3-setuptools python3-gnupg python3-debian zstd )
-
+    
     apt-get install --yes --no-install-recommends "${PREREQ_PKG[@]}"
-
+    
     curl -Lo "/tmp/$PKG" "$URL"
-
-    # If we're on debian, zstd compression isn't supported by pkg.
-    # So we repackage.
+    
+    # If Running on Debian, zstd compression isn't supported by pkg.
+    # The code below repackages the deb packages using xz instead.
     if [[ "$ID" == 'debian' ]]; then
         echo "We're on debian, so repackaging without zstd compression..."
         rm -r /tmp/repolib.tmp 2>/dev/null || true
@@ -112,9 +119,11 @@ steps below (At the time of writing this, the version is 2.0.0):
         && ar -m -c -a sdsd "/tmp/${PKG}" debian-binary control.tar.xz data.tar.xz \
         && popd >/dev/null
     fi
-
+    
     # Install the package
     apt-get install --yes "/tmp/$PKG"
+
+__ https://github.com/pop-os/repolib/releases/
 
 Uninstall
 ^^^^^^^^^

--- a/README.rst
+++ b/README.rst
@@ -81,14 +81,10 @@ If your operating system packages repolib, you can install it by running::
 From Pre-Compiled .deb Package
 ------------------------------
 
-When using any other Debian based distro, it's possible to install the
-`latest release`__ using the `quick_install.sh`__ script:
-
-.. code:: shell
-
-    sudo apt update && sudo apt install --yes --no-install-recommends curl
-    sudo bash <(curl -s https://raw.githubusercontent.com/pop-os/repolib/HEAD/quick-install.sh)
-
+If your distro does not yet supply the package, you can download and
+install the .deb package from the `latest release`__.  
+A script to do this automatically can be found in `quick_install.sh`__ script.
+ 
 __ https://github.com/pop-os/repolib/releases/
 __ https://github.com/pop-os/repolib/blob/HEAD/quick-install.sh
 

--- a/quick-install.sh
+++ b/quick-install.sh
@@ -5,6 +5,12 @@
 # Invoke this script by calling (as root):
 # bash <(curl https://raw.githubusercontent.com/pop-os/repolib/HEAD/quick-install.sh)
 
+# As of 2023-08-15, This script has been tested with the following
+# Docker containers:
+#   debian:latest debian:12-slim debian:11-slim debian:10-slim
+#   debian:oldstable-slim debian:sid-slim
+#   ubuntu:latest ubuntu:23.04 ubuntu:22.04 ubuntu:devel
+
 set -e
 
 has() { command -v "$1" > /dev/null; }
@@ -26,7 +32,7 @@ if ! has apt-manage; then
 
         apt-get update
         # For the odd case where /tmp is missing
-        # (might happen in some obscure docker images)
+        # (might happen in some obscure Docker images)
         mkdir -p /tmp
 
         # Initialize some useful variables
@@ -70,7 +76,9 @@ if ! has apt-manage; then
     fi
 fi
 
-# Passing '-' as the sole argument, will not run apt-manage, otherwise
-# it will run it with the any argument provided, or with --help to
-# indicate a successful installation.
-[[ $# -eq 1 && "$1" == "-" ]] || apt-manage "${@:---help}"
+if has apt-manage; then
+    echo "apt-manage successfully installed"
+else
+    echo "Something went wrong, apt-manage isn't found"
+    exit 1
+fi

--- a/quick-install.sh
+++ b/quick-install.sh
@@ -22,13 +22,17 @@ if ! has apt-manage; then
     if ! has apt-manage; then
         mkdir -p /tmp
 
+        # Initialize some useful variables
         PKG=python3-repolib_2.0.0_all.deb
         URL="https://github.com/pop-os/repolib/releases/download/2.0.0/$PKG"
 
         if [ ! -e "/tmp/$PKG" ]; then
             PREREQ_PKG=(curl python3-gnupg python3-debian ca-certificates)
+            # Grab VERSION_ID and ID from /etc/os-release
             . <(grep -E '^(VERSION_)?ID=' /etc/os-release)
 
+            # Make sure we're using the right mix.
+            # Debian requires some missing packages.
             [[ "$ID" == 'debian' ]] \
             && PREREQ_PKG+=( debhelper dh-python python3-all \
                 python3-setuptools python3-gnupg python3-debian zstd )
@@ -37,6 +41,8 @@ if ! has apt-manage; then
             
             curl -Lo "/tmp/$PKG" "$URL"
 
+            # If Running on Debian, zstd compression isn't supported by pkg.
+            # The code below repackages the deb packages using xz instead.
             if [[ "$ID" == 'debian' ]]; then
                 echo "We're on debian, so repackaging without zstd compression..."
                 rm -r /tmp/repolib.tmp 2>/dev/null || true
@@ -49,6 +55,8 @@ if ! has apt-manage; then
                 && popd >/dev/null
             fi
         fi
+
+        # Install the package
         apt-get install --yes "/tmp/$PKG"
     fi
 fi

--- a/quick-install.sh
+++ b/quick-install.sh
@@ -23,8 +23,9 @@ if ! has apt-manage; then
         mkdir -p /tmp
 
         # Initialize some useful variables
-        PKG=python3-repolib_2.0.0_all.deb
-        URL="https://github.com/pop-os/repolib/releases/download/2.0.0/$PKG"
+        PKG_VER='2.0.0'
+        PKG="python3-repolib_${PKG_VER}_all.deb"
+        URL="https://github.com/pop-os/repolib/releases/download/${PKG_VER}/$PKG"
 
         if [ ! -e "/tmp/$PKG" ]; then
             PREREQ_PKG=(curl python3-gnupg python3-debian ca-certificates)

--- a/quick-install.sh
+++ b/quick-install.sh
@@ -2,7 +2,8 @@
 # originally posted at https://askubuntu.com/a/1412554/720005
 # shellcheck disable=SC1090
 
-# Invoke this script by calling (as root):
+# It should be possible to execut this script as a oneliner with curl
+# (check that it is installed first). For example in bash/zsh (as root):
 # bash <(curl https://raw.githubusercontent.com/pop-os/repolib/HEAD/quick-install.sh)
 
 # As of 2023-08-15, This script has been tested with the following
@@ -82,3 +83,5 @@ else
     echo "Something went wrong, apt-manage isn't found"
     exit 1
 fi
+
+#

--- a/quick-install.sh
+++ b/quick-install.sh
@@ -1,0 +1,56 @@
+#! /usr/bin/env bash
+# originally posted at https://askubuntu.com/a/1412554/720005
+# shellcheck disable=SC1090
+
+# Invoke this script by calling:
+# # bash <(curl https://raw.githubusercontent.com/pop-os/repolib/HEAD/quick-install.sh)
+
+set -e
+
+has() { command -v "$1" > /dev/null; }
+
+if ! has apt-manage; then
+    export DEBIAN_FRONTEND=noninteractive
+
+    apt-get update
+
+    # Try differnt ways of installing apt-manage
+    # First let's hope there is package ready for installation
+    apt-get install --yes apt-manage || true
+
+    # If it still doesn't exist, let's get it from repo
+    if ! has apt-manage; then
+        mkdir -p /tmp
+
+        PKG=python3-repolib_2.0.0_all.deb
+        URL="https://github.com/pop-os/repolib/releases/download/2.0.0/$PKG"
+
+        if [ ! -e "/tmp/$PKG" ]; then
+            PREREQ_PKG=(curl python3-gnupg python3-debian ca-certificates)
+            . <(grep -E '^(VERSION_)?ID=' /etc/os-release)
+
+            [[ "$ID" == 'debian' ]] \
+            && PREREQ_PKG+=( debhelper dh-python python3-all \
+                python3-setuptools python3-gnupg python3-debian zstd )
+
+            apt-get install --yes --no-install-recommends "${PREREQ_PKG[@]}"
+            
+            curl -Lo "/tmp/$PKG" "$URL"
+
+            if [[ "$ID" == 'debian' ]]; then
+                echo "We're on debian, so repackaging without zstd compression..."
+                rm -r /tmp/repolib.tmp 2>/dev/null || true
+                mkdir -p /tmp/repolib.tmp && pushd /tmp/repolib.tmp/ >/dev/null \
+                && mv "/tmp/${PKG}" "${PKG}.tmp" \
+                && ar x "${PKG}.tmp" \
+                && zstd -d < control.tar.zst | xz > control.tar.xz \
+                && zstd -d < data.tar.zst | xz > data.tar.xz \
+                && ar -m -c -a sdsd "/tmp/${PKG}" debian-binary control.tar.xz data.tar.xz \
+                && popd >/dev/null
+            fi
+        fi
+        apt-get install --yes "/tmp/$PKG"
+    fi
+fi
+
+apt-manage "${@:---help}"

--- a/quick-install.sh
+++ b/quick-install.sh
@@ -2,8 +2,9 @@
 # originally posted at https://askubuntu.com/a/1412554/720005
 # shellcheck disable=SC1090
 
-# Invoke this script by calling (as root):
-# bash <(curl https://raw.githubusercontent.com/pop-os/repolib/HEAD/quick-install.sh)
+# It should be possible to execut this script as a one-liner with curl
+# (check that it is installed first). Example (as root):
+# curl https://raw.githubusercontent.com/pop-os/repolib/HEAD/quick-install.sh | bash 
 
 # As of 2023-08-15, This script has been tested with the following
 # Docker containers:
@@ -82,3 +83,5 @@ else
     echo "Something went wrong, apt-manage isn't found"
     exit 1
 fi
+
+#


### PR DESCRIPTION
Following up on #69, I present here the results of my own personal experience with installing apt-manage.

I've manually tested the quick-install script using Docker hub's images for ubuntu:18.04, ubuntu:20.04, ubuntu:22.04 and ubuntu:latest, as well as debian:10, debian:11 and debian:latest.

Let me know if this PR is not acceptable or if it breaks any internal rules.