### PR TITLE
Add missing dependencies for Debian compile instructions

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -132,10 +132,12 @@ it onto your system. You will need the following build-dependencies:
     * dh-python
     * python3-all
     * python3-setuptools
+    * python3-gnupg
+    * python3-pytest
 
 You can use this command to install these all in one go::
 
-    sudo apt install debhelper dh-python python3-all python3-setuptools
+    sudo apt install debhelper dh-python python3-all python3-setuptools python3-gnupg python3-pytest
 
 Then build and install the package::
 

--- a/README.rst
+++ b/README.rst
@@ -131,13 +131,19 @@ it onto your system. You will need the following build-dependencies:
     * debhelper (>=11)
     * dh-python
     * python3-all
-    * python3-setuptools
+    * python3-dbus
+    * python3-debian
+    * python3-distro
+    * python3-distutils
     * python3-gnupg
+    * python3-launchpadlib
+    * python3-lazr.restfulclient
     * python3-pytest
+    * python3-setuptools
 
 You can use this command to install these all in one go::
 
-    sudo apt install debhelper dh-python python3-all python3-setuptools python3-gnupg python3-pytest
+    sudo apt install debhelper dh-python python3-all python3-dbus python3-debian python3-distro python3-distutils python3-gnupg python3-launchpadlib python3-lazr.restfulclient python3-pytest python3-setuptools
 
 Then build and install the package::
 


### PR DESCRIPTION
Found that on an Ubuntu 22.04 install I was missing `python3-gnupg` and `python3-pytest`, so I took the opportunity to list all deps from [debian/control](https://github.com/pop-os/repolib/blob/9d42c379e4ddde06d4ae54ca19d71ab57c42114e/debian/control#L5-L16) 