### PR TITLE
Docs: replace invalid example PPA with System76 pre-stable PPA

### DIFF
--- a/docs/deb822-format.rst
+++ b/docs/deb822-format.rst
@@ -268,9 +268,9 @@ This specifies a source for downloading packages for System76's Pop!_OS::
 
 Following is a PPA source which has been disabled::
 
-    X-Repolib-Name: ZNC Stable
+    X-Repolib-Name: System76 Pre-Stable
     Enabled: no
     Types: deb
-    URIs: http://ppa.launchpad.net/teward/znc/ubuntu
+    URIs: http://ppa.launchpad.net/system76/pre-stable/ubuntu
     Suites: disco
     Components: main


### PR DESCRIPTION
I think the idea was to show a PPA that should be disabled since it's no longer valid. To me, using a PPA that should be disabled because it's not recommended for general usage is also a perfectly fine example.

Closes: https://github.com/pop-os/repolib/issues/72