### PR TITLE
fix(build): add apt-manage to pyproject.toml

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -38,6 +38,9 @@ dependencies = [
 "Bug Tracker" = "https://github.com/pop-os/repolib/issues"
 "Documentation" = "https://repolib.readthedocs.io/en/latest/"
 
+[project.scripts]
+apt-manage = "repolib.command:bin.apt_manage"
+
 [tool.commitizen]
 name = "cz_conventional_commits"
 version = "2.2.1"


### PR DESCRIPTION
Make sure that apt-manage script gets installed into python environment to allow using repolib with e.g. pipx.