### PR TITLE
fix(file): fix parsing of folded deb822 multi-value fields

### DIFF
--- a/src/repolib/file.py
+++ b/src/repolib/file.py
@@ -391,7 +391,7 @@ class SourceFile:
                     item += 1
                     self.contents.append('')
                 else:
-                    raw822.append(line.strip())
+                    raw822.append(line)
         
         if raw822:
             parsing_deb822 = False


### PR DESCRIPTION
Allow sources sections containing multiline values (e.g. URIs:) in:

```
Enabled: yes
Types: deb
URIs:  https://artifacts.elastic.co/packages/7.x/apt
 https://artifacts.elastic.co/packages/8.x/apt
Suites: stable
Components: main
Signed-By: /etc/apt/keyrings/elastic.gpg
```

Without the fix, only the first URI is parsed (the second URI gets parsed into a new key/value pair with key 'https' and value '//artifacts/...').