### PR TITLE
fix(cli/list): fix listing of legacy sources when sources.list is missing

### DIFF
--- a/src/repolib/command/list.py
+++ b/src/repolib/command/list.py
@@ -122,24 +122,22 @@ class List(Command):
             list_file(Path): The sources.list file to try and parse.
             indent(str): An indentation to append to the output
         """
-        try:
-            sources_list_file = util.SOURCES_DIR.parent / 'sources.list'
-        except FileNotFoundError:
-            sources_list_file = None
+        sources_list_file = util.SOURCES_DIR.parent / 'sources.list'
+        if not sources_list_file.is_file():
+            return
 
         print('Legacy source.list sources:')
-        if sources_list_file:
-            with open(sources_list_file, mode='r') as file:
-                for line in file:
-                    if 'cdrom' in line:
-                        line = ''
-                    
-                    try: 
-                        source = Source()
-                        source.load_from_data([line])
-                        print(textwrap.indent(source.ui, indent))
-                    except SourceError:
-                        pass
+        with open(sources_list_file, mode='r') as file:
+            for line in file:
+                if 'cdrom' in line:
+                    line = ''
+
+                try:
+                    source = Source()
+                    source.load_from_data([line])
+                    print(textwrap.indent(source.ui, indent))
+                except SourceError:
+                    pass
 
     def list_all(self):
         """List all sources presently configured in the system


### PR DESCRIPTION
The handling of a missing sources.list file when listing of legacy sources (using the list -l option) was broken and did not detect the missing file. This PR fixes the problem.