### PR TITLE
Specify User-Agent when downloading keys

### DIFF
--- a/src/repolib/key.py
+++ b/src/repolib/key.py
@@ -185,7 +185,10 @@ class SourceKey:
             return
         
         if 'url' in kwargs:
-            req = request.Request(kwargs['url'])
+            req = request.Request(
+                kwargs['url'],
+                headers={"User-Agent": "python-requests/2.31.0"},
+            )
             with request.urlopen(req) as response:
                 self.data = response.read().decode('UTF-8')
                 self.gpg.import_keys(self.data)


### PR DESCRIPTION
Fix #82

This would be for free if we used `requests` but I wasn't sure if you intentionally didn't want to introduce that dependency. Also, we could use any User-Agent string that you prefer, curl and Mozilla work fine too.