### PR TITLE
Remove duplicate `Source.signed_by` assignment

### DIFF
--- a/src/repolib/source.py
+++ b/src/repolib/source.py
@@ -179,7 +179,6 @@ class Source(deb822.Deb822):
         self.suites = []
         self.components = []
         self.comments = []
-        self.signed_by = None
         self.architectures = ''
         self.languages = ''
         self.targets = ''


### PR DESCRIPTION
`Source.signed_by` is reassigned to an empty string a few lines below in `Source.reset_values()`.