### PR TITLE
`load_all_sources()` load source files once

### DIFF
--- a/src/repolib/system.py
+++ b/src/repolib/system.py
@@ -50,9 +50,8 @@ def load_all_sources() -> None:
             log.info("Ignoring directory '%s'", file)
             continue
         try:
-            sourcefile = SourceFile(name=file.stem)
             log.debug('Loading %s', file)
-            sourcefile.load()
+            sourcefile = SourceFile(name=file.stem)
             if file.name not in util.files:
                 util.files[file.name] = sourcefile
 

--- a/src/repolib/unittest/test_system.py
+++ b/src/repolib/unittest/test_system.py
@@ -1,0 +1,55 @@
+#!/usr/bin/python3
+
+"""
+Copyright 2026 System76
+All rights reserved.
+
+This file is part of RepoLib.
+
+RepoLib is free software: you can redistribute it and/or modify
+it under the terms of the GNU Lesser General Public License as published by
+the Free Software Foundation, either version 3 of the License, or
+(at your option) any later version.
+
+RepoLib is distributed in the hope that it will be useful,
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+GNU Lesser General Public License for more details.
+
+You should have received a copy of the GNU Lesser General Public License
+along with RepoLib.  If not, see <https://www.gnu.org/licenses/>.
+"""
+
+import unittest
+from pathlib import Path
+
+from .. import system, util
+
+
+class SystemTestCase(unittest.TestCase):
+    def setUp(self):
+        util.set_testing()
+        self.test_sources = {
+            "example-legacy.list": "deb https://foo.example.com stable main\n",
+            "example-deb822.sources": (
+                "Types: deb\n"
+                "URIs: https://packages.example.com\n"
+                "Suites: stable\n"
+                "Components: main\n"
+                "Architectures: amd64\n"
+                "Signed-By: /usr/share/keyrings/example.gpg\n"
+            ),
+        }
+        util.SOURCES_DIR.mkdir(parents=True)
+        for name, content in self.test_sources.items():
+            src_path = Path(util.SOURCES_DIR / name)
+            with open(src_path, mode="w") as output_file:
+                output_file.write(content)
+
+    def test_load_all_sources(self):
+        system.load_all_sources()
+        self.assertEqual(len(util.sources), len(self.test_sources))
+        self.assertTrue("example-legacy" in util.sources)
+        self.assertTrue("example-deb822" in util.sources)
+        self.assertTrue("example-legacy.list" in util.files)
+        self.assertTrue("example-deb822.sources" in util.files)


### PR DESCRIPTION
`load_all_sources()` loads the source files twice, once when an instance of `SourceFile()` is created with the source file, followed by an explicit `load()` call. This change removes the explicit call.

Adds tests to verify that loading continues to work.